### PR TITLE
Adjust ValueWrapper to not convert datetime values to string when using Parameterization

### DIFF
--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -2,7 +2,7 @@ import inspect
 import json
 import re
 import uuid
-from datetime import date, time
+from datetime import date, time, datetime
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -461,8 +461,8 @@ class ValueWrapper(Term):
             )
             return format_alias_sql(sql, self.alias, quote_char=quote_char, **kwargs)
 
-        # Don't stringify numbers when using a parameter
-        if isinstance(self.value, (int, float)):
+        # Don't stringify number or date values when using a parameter
+        if isinstance(self.value, (int, float, date, time, datetime)):
             value_sql = self.value
         else:
             value_sql = self.get_value_sql(quote_char=quote_char, **kwargs)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -130,7 +130,7 @@ class ParametrizedTestsWithValues(unittest.TestCase):
             'SELECT * FROM "abc" JOIN "efg" ON "abc"."id"="efg"."abc_id" WHERE "abc"."category"=%s AND "efg"."date">=%s LIMIT 10',
             sql,
         )
-        self.assertEqual(["foobar", "2024-02-22"], parameter.get_parameters())
+        self.assertEqual(["foobar", date(2024, 2, 22)], parameter.get_parameters())
 
     def test_param_select_subquery(self):
         q = (
@@ -153,7 +153,7 @@ class ParametrizedTestsWithValues(unittest.TestCase):
             'SELECT * FROM "abc" WHERE "category"=&1 AND "id" IN (SELECT "abc_id" FROM "efg" WHERE "date">=&2) LIMIT 10',
             sql,
         )
-        self.assertEqual(["foobar", "2024-02-22"], parameter.get_parameters())
+        self.assertEqual(["foobar", date(2024, 2, 22)], parameter.get_parameters())
 
     def test_join(self):
         subquery = (


### PR DESCRIPTION
When working on fixing test cases for my [PR on Tortoise](https://github.com/tortoise/tortoise-orm/pull/1725), I noticed that the asyncpg connection driver was complaining on the test_time test cases, because a string value was given where it expects a date/time/datetime value. This PR fixes this behavior.