### PR TITLE
fix: query copying

### DIFF
--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -757,7 +757,6 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
     def __copy__(self) -> "Self":
         newone = type(self).__new__(type(self))
         newone.__dict__.update(self.__dict__)
-        newone._select_star_tables = copy(self._select_star_tables)
         newone._from = copy(self._from)
         newone._with = copy(self._with)
         newone._selects = copy(self._selects)
@@ -768,6 +767,9 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
         newone._joins = copy(self._joins)
         newone._unions = copy(self._unions)
         newone._updates = copy(self._updates)
+        newone._select_star_tables = copy(self._select_star_tables)
+        newone._on_conflict_fields = copy(self._on_conflict_fields)
+        newone._on_conflict_do_updates = copy(self._on_conflict_do_updates)
         return newone
 
     @builder

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,5 @@
 import unittest
+from copy import copy
 
 from pypika import Case, Query, Tables, Tuple, functions
 from pypika.dialects import (
@@ -175,3 +176,36 @@ class QueryBuilderTests(unittest.TestCase):
 
         with self.subTest("SQLLiteQueryBuilder"):
             self.assertEqual(SQLLiteQuery, SQLLiteQueryBuilder.QUERY_CLS)
+
+    def test_query_builder_copy(self):
+        qb = QueryBuilder()
+        qb2 = copy(qb)
+
+        self.assertIsNot(qb, qb2)
+        self.assertEqual(qb, qb2)
+        self.assertEqual(qb._select_star_tables, qb2._select_star_tables)
+        self.assertIsNot(qb._select_star_tables, qb2._select_star_tables)
+        self.assertEqual(qb._from, qb2._from)
+        self.assertIsNot(qb._from, qb2._from)
+        self.assertEqual(qb._with, qb2._with)
+        self.assertIsNot(qb._with, qb2._with)
+        self.assertEqual(qb._selects, qb2._selects)
+        self.assertIsNot(qb._selects, qb2._selects)
+        self.assertEqual(qb._columns, qb2._columns)
+        self.assertIsNot(qb._columns, qb2._columns)
+        self.assertEqual(qb._values, qb2._values)
+        self.assertIsNot(qb._values, qb2._values)
+        self.assertEqual(qb._groupbys, qb2._groupbys)
+        self.assertIsNot(qb._groupbys, qb2._groupbys)
+        self.assertEqual(qb._orderbys, qb2._orderbys)
+        self.assertIsNot(qb._orderbys, qb2._orderbys)
+        self.assertEqual(qb._joins, qb2._joins)
+        self.assertIsNot(qb._joins, qb2._joins)
+        self.assertEqual(qb._unions, qb2._unions)
+        self.assertIsNot(qb._unions, qb2._unions)
+        self.assertEqual(qb._updates, qb2._updates)
+        self.assertIsNot(qb._updates, qb2._updates)
+        self.assertEqual(qb._on_conflict_fields, qb2._on_conflict_fields)
+        self.assertIsNot(qb._on_conflict_fields, qb2._on_conflict_fields)
+        self.assertEqual(qb._on_conflict_do_updates, qb2._on_conflict_do_updates)
+        self.assertIsNot(qb._on_conflict_do_updates, qb2._on_conflict_do_updates)


### PR DESCRIPTION
# Overview

This fixes the issue where the copies of a query might share a state - `QueryBuilder._on_conflict_fields`. This PR should fix https://github.com/tortoise/tortoise-orm/issues/1722 in tortoise-orm.

# Issue

```
from pypika.dialects.postgresql import PostgreSQLQuery
from pypika.queries import Table


table_abc = Table("abc")
base_query = PostgreSQLQuery.into(table_abc).insert(1)

query1 = base_query.on_conflict(table_abc.id).do_nothing()
print("query1 before the issue:", query1)

# this introduces an issue
query2 = base_query.on_conflict(table_abc.id).do_nothing()
print("query1:", query1)
print("query2:", query2)

```

This will print

```
query before the issue INSERT INTO "abc" VALUES (1) ON CONFLICT ("id") DO NOTHING
query1 INSERT INTO "abc" VALUES (1) ON CONFLICT ("id", "id") DO NOTHING
query2 INSERT INTO "abc" VALUES (1) ON CONFLICT ("id", "id") DO NOTHING
```

Please note `... ON CONFLICT ("id", "id") ...` after the second query was created!

Here's the code in `tortoise-orm` which is affected by this issue
https://github.com/tortoise/tortoise-orm/blob/0ddf8d327949be3ad812c41e4215c85b997214b9/tortoise/queryset.py#L1882