### PR TITLE
Parameterization support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # ChangeLog
 
+## 0.3
+
+## 0.3.0
+- Add `Parameterizer`
+- Uppdate `Parameter` to be dialect-aware
+- Remove `ListParameter`, `DictParameter`, `QmarkParameter`, etc.
+- Wrap query's offset and limit with ValueWrapper so they can be parametrized
+- Fix a missing whitespace for MSSQL when pagination without ordering is used
+
 ## 0.2
 
 ### 0.2.2

--- a/pypika/__init__.py
+++ b/pypika/__init__.py
@@ -21,19 +21,16 @@ from pypika.terms import (
     CustomFunction,
     EmptyCriterion,
     Field,
-    FormatParameter,
     Index,
     Interval,
-    NamedParameter,
     Not,
     NullValue,
-    NumericParameter,
     Parameter,
-    PyformatParameter,
-    QmarkParameter,
+    Parameterizer,
     Rollup,
     SystemTimeValue,
     Tuple,
+    ValueWrapper,
 )
 
 NULL = NullValue()

--- a/pypika/dialects/mssql.py
+++ b/pypika/dialects/mssql.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from pypika.enums import Dialects
 from pypika.exceptions import QueryException
 from pypika.queries import Query, QueryBuilder
+from pypika.terms import ValueWrapper
 from pypika.utils import builder
 
 
@@ -42,7 +43,7 @@ class MSSQLQueryBuilder(QueryBuilder):
     @builder
     def fetch_next(self, limit: int) -> MSSQLQueryBuilder:  # type:ignore[return]
         # Overridden to provide a more domain-specific API for T-SQL users
-        self._limit = limit
+        self._limit = cast(ValueWrapper, self.wrap_constant(limit))
 
     def _offset_sql(self, **kwargs) -> str:
         order_by = ""
@@ -53,6 +54,8 @@ class MSSQLQueryBuilder(QueryBuilder):
         )
 
     def _limit_sql(self, **kwargs) -> str:
+        if self._limit is None:
+            return ""
         return " FETCH NEXT {limit} ROWS ONLY".format(limit=self._limit.get_sql(**kwargs))
 
     def _apply_pagination(self, querystring: str, **kwargs) -> str:

--- a/pypika/dialects/mssql.py
+++ b/pypika/dialects/mssql.py
@@ -47,7 +47,7 @@ class MSSQLQueryBuilder(QueryBuilder):
     def _offset_sql(self) -> str:
         order_by = ""
         if not self._orderbys:
-            order_by = "ORDER BY (SELECT 0)"
+            order_by = " ORDER BY (SELECT 0)"
         return order_by + " OFFSET {offset} ROWS".format(offset=self._offset or 0)
 
     def _limit_sql(self) -> str:

--- a/pypika/dialects/oracle.py
+++ b/pypika/dialects/oracle.py
@@ -29,7 +29,11 @@ class OracleQueryBuilder(QueryBuilder):
         return super().get_sql(*args, **kwargs)
 
     def _offset_sql(self, **kwargs) -> str:
+        if self._offset is None:
+            return ""
         return " OFFSET {offset} ROWS".format(offset=self._offset.get_sql(**kwargs))
 
     def _limit_sql(self, **kwargs) -> str:
+        if self._limit is None:
+            return ""
         return " FETCH NEXT {limit} ROWS ONLY".format(limit=self._limit.get_sql(**kwargs))

--- a/pypika/dialects/oracle.py
+++ b/pypika/dialects/oracle.py
@@ -28,8 +28,8 @@ class OracleQueryBuilder(QueryBuilder):
         kwargs["groupby_alias"] = False
         return super().get_sql(*args, **kwargs)
 
-    def _offset_sql(self) -> str:
-        return " OFFSET {offset} ROWS".format(offset=self._offset)
+    def _offset_sql(self, **kwargs) -> str:
+        return " OFFSET {offset} ROWS".format(offset=self._offset.get_sql(**kwargs))
 
-    def _limit_sql(self) -> str:
-        return " FETCH NEXT {limit} ROWS ONLY".format(limit=self._limit)
+    def _limit_sql(self, **kwargs) -> str:
+        return " FETCH NEXT {limit} ROWS ONLY".format(limit=self._limit.get_sql(**kwargs))

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -1252,7 +1252,8 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
     @builder
     def set(self, field: Field | str, value: Any) -> "Self":  # type:ignore[return]
         field = Field(field) if not isinstance(field, Field) else field
-        self._updates.append((field, self._wrapper_cls(value)))
+        value = self.wrap_constant(value, wrapper_cls=self._wrapper_cls)
+        self._updates.append((field, value))
 
     def __add__(self, other: Self) -> _SetOperation:  # type:ignore[override]
         return self.union(other)

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -367,7 +367,8 @@ class Parameterizer:
     be accessed via the `values` attribute.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, placeholder_factory: Optional[Callable[[int], str]] = None) -> None:
+        self.placeholder_factory = placeholder_factory
         self.values = []
 
     def should_parameterize(self, value: Any) -> bool:
@@ -380,7 +381,10 @@ class Parameterizer:
 
     def create_param(self, value: Any) -> Parameter:
         self.values.append(value)
-        return Parameter(idx=len(self.values))
+        if self.placeholder_factory:
+            return Parameter(self.placeholder_factory(len(self.values)))
+        else:
+            return Parameter(idx=len(self.values))
 
 
 class Negative(Term):

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -370,9 +370,9 @@ class Parameterizer:
     be accessed via the `values` attribute.
     """
 
-    def __init__(self, placeholder_factory: Optional[Callable[[int], str]] = None) -> None:
+    def __init__(self, placeholder_factory: Callable[[int], str] | None = None) -> None:
         self.placeholder_factory = placeholder_factory
-        self.values = []
+        self.values: list = []
 
     def should_parameterize(self, value: Any) -> bool:
         if isinstance(value, Enum):

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -1510,7 +1510,7 @@ class Function(Criterion):
 
         # FIXME escape
         function_sql = self.get_function_sql(
-            with_namespace=with_namespace, quote_char=quote_char, dialect=dialect
+            with_namespace=with_namespace, quote_char=quote_char, dialect=dialect, **kwargs
         )
 
         if self.schema is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypika-tortoise"
-version = "0.2.2"
+version = "0.3.0"
 description = "Forked from pypika and streamline just for tortoise-orm"
 authors = ["long2ice <long2ice@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -11,7 +11,8 @@ from pypika import (
     Query,
     Tables,
 )
-from pypika.terms import ListParameter, ParameterValueWrapper
+from pypika.functions import Upper
+from pypika.terms import ListParameter, ParameterValueWrapper, ValueWrapper
 
 
 class ParametrizedTests(unittest.TestCase):
@@ -212,3 +213,15 @@ class ParametrizedTestsWithValues(unittest.TestCase):
             'INSERT INTO "abc" ("a","b","c") VALUES (%(param1)s,%(param2)s,%(param3)s)', sql
         )
         self.assertEqual({"param1": 1, "param2": 2.2, "param3": "foo"}, parameter.get_parameters())
+
+    def test_function_parameter(self):
+        q = (
+            Query.from_(self.table_abc)
+            .select("*")
+            .where(self.table_abc.category == Upper(ValueWrapper("foobar")))
+        )
+        p = ListParameter("%s")
+        sql = q.get_sql(parameter=p)
+        self.assertEqual('SELECT * FROM "abc" WHERE "category"=UPPER(%s)', sql)
+
+        self.assertEqual(["foobar"], p.get_parameters())

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -235,3 +235,8 @@ class ParameterizerTests(unittest.TestCase):
             'SELECT * FROM "abc" ORDER BY (SELECT 0) OFFSET ? ROWS FETCH NEXT ? ROWS ONLY', sql
         )
         self.assertEqual([5, 10], parameterizer.values)
+
+    def test_placeholder_factory(self):
+        parameterizer = Parameterizer(placeholder_factory=lambda _: "%s")
+        param = parameterizer.create_param(1)
+        self.assertEqual("%s", param.get_sql())

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,18 +1,10 @@
 import unittest
 from datetime import date
 
-from pypika import (
-    FormatParameter,
-    NamedParameter,
-    NumericParameter,
-    Parameter,
-    PyformatParameter,
-    QmarkParameter,
-    Query,
-    Tables,
-)
+from pypika import Parameter, Query, Tables, ValueWrapper
+from pypika.enums import Dialects
 from pypika.functions import Upper
-from pypika.terms import ListParameter, ParameterValueWrapper, ValueWrapper
+from pypika.terms import Case, Parameterizer
 
 
 class ParametrizedTests(unittest.TestCase):
@@ -87,34 +79,41 @@ class ParametrizedTests(unittest.TestCase):
         )
 
     def test_qmark_parameter(self):
-        self.assertEqual("?", QmarkParameter().get_sql())
+        self.assertEqual("?", Parameter("?").get_sql())
 
-    def test_numeric_parameter(self):
-        self.assertEqual(":14", NumericParameter("14").get_sql())
-        self.assertEqual(":15", NumericParameter(15).get_sql())
+    def test_oracle(self):
+        self.assertEqual("?", Parameter(idx=1).get_sql(dialect=Dialects.ORACLE))
+        self.assertEqual("?", Parameter(idx=2).get_sql(dialect=Dialects.ORACLE))
 
-    def test_named_parameter(self):
-        self.assertEqual(":buz", NamedParameter("buz").get_sql())
+    def test_mssql(self):
+        self.assertEqual("?", Parameter(idx=1).get_sql(dialect=Dialects.MSSQL))
+        self.assertEqual("?", Parameter(idx=2).get_sql(dialect=Dialects.MSSQL))
 
-    def test_format_parameter(self):
-        self.assertEqual("%s", FormatParameter().get_sql())
+    def test_mysql(self):
+        self.assertEqual("%s", Parameter(idx=1).get_sql(dialect=Dialects.MYSQL))
+        self.assertEqual("%s", Parameter(idx=2).get_sql(dialect=Dialects.MYSQL))
 
-    def test_pyformat_parameter(self):
-        self.assertEqual("%(buz)s", PyformatParameter("buz").get_sql())
+    def test_postgres(self):
+        self.assertEqual("$1", Parameter(idx=1).get_sql(dialect=Dialects.POSTGRESQL))
+        self.assertEqual("$2", Parameter(idx=2).get_sql(dialect=Dialects.POSTGRESQL))
+
+    def test_sqlite(self):
+        self.assertEqual("?", Parameter(idx=1).get_sql(dialect=Dialects.SQLITE))
+        self.assertEqual("?", Parameter(idx=2).get_sql(dialect=Dialects.SQLITE))
 
 
-class ParametrizedTestsWithValues(unittest.TestCase):
+class ParameterizerTests(unittest.TestCase):
     table_abc, table_efg = Tables("abc", "efg")
 
     def test_param_insert(self):
         q = Query.into(self.table_abc).columns("a", "b", "c").insert(1, 2.2, "foo")
 
-        parameter = QmarkParameter()
-        sql = q.get_sql(parameter=parameter)
+        parameterizer = Parameterizer()
+        sql = q.get_sql(parameterizer=parameterizer)
         self.assertEqual('INSERT INTO "abc" ("a","b","c") VALUES (?,?,?)', sql)
-        self.assertEqual([1, 2.2, "foo"], parameter.get_parameters())
+        self.assertEqual([1, 2.2, "foo"], parameterizer.values)
 
-    def test_param_select_join(self):
+    def test_select_join_in_mysql(self):
         q = (
             Query.from_(self.table_abc)
             .select("*")
@@ -125,15 +124,15 @@ class ParametrizedTestsWithValues(unittest.TestCase):
             .limit(10)
         )
 
-        parameter = FormatParameter()
-        sql = q.get_sql(parameter=parameter)
+        parameterizer = Parameterizer()
+        sql = q.get_sql(parameterizer=parameterizer, dialect=Dialects.MYSQL)
         self.assertEqual(
             'SELECT * FROM "abc" JOIN "efg" ON "abc"."id"="efg"."abc_id" WHERE "abc"."category"=%s AND "efg"."date">=%s LIMIT 10',
             sql,
         )
-        self.assertEqual(["foobar", date(2024, 2, 22)], parameter.get_parameters())
+        self.assertEqual(["foobar", date(2024, 2, 22)], parameterizer.values)
 
-    def test_param_select_subquery(self):
+    def test_select_subquery_in_postgres(self):
         q = (
             Query.from_(self.table_abc)
             .select("*")
@@ -148,15 +147,15 @@ class ParametrizedTestsWithValues(unittest.TestCase):
             .limit(10)
         )
 
-        parameter = ListParameter(placeholder=lambda idx: f"&{idx+1}")
-        sql = q.get_sql(parameter=parameter)
+        parameterizer = Parameterizer()
+        sql = q.get_sql(parameterizer=parameterizer, dialect=Dialects.POSTGRESQL)
         self.assertEqual(
-            'SELECT * FROM "abc" WHERE "category"=&1 AND "id" IN (SELECT "abc_id" FROM "efg" WHERE "date">=&2) LIMIT 10',
+            'SELECT * FROM "abc" WHERE "category"=$1 AND "id" IN (SELECT "abc_id" FROM "efg" WHERE "date">=$2) LIMIT 10',
             sql,
         )
-        self.assertEqual(["foobar", date(2024, 2, 22)], parameter.get_parameters())
+        self.assertEqual(["foobar", date(2024, 2, 22)], parameterizer.values)
 
-    def test_join(self):
+    def test_join_in_postgres(self):
         subquery = (
             Query.from_(self.table_efg)
             .select(self.table_efg.fiz, self.table_efg.buz)
@@ -171,48 +170,14 @@ class ParametrizedTestsWithValues(unittest.TestCase):
             .where(self.table_abc.bar == "bar")
         )
 
-        parameter = NamedParameter()
-        sql = q.get_sql(parameter=parameter)
+        parameterizer = Parameterizer()
+        sql = q.get_sql(parameterizer=parameterizer, dialect=Dialects.POSTGRESQL)
         self.assertEqual(
-            'SELECT "abc"."foo","sq0"."fiz" FROM "abc" JOIN (SELECT "fiz","buz" FROM "efg" WHERE "buz"=:param1)'
-            ' "sq0" ON "abc"."bar"="sq0"."buz" WHERE "abc"."bar"=:param2',
+            'SELECT "abc"."foo","sq0"."fiz" FROM "abc" JOIN (SELECT "fiz","buz" FROM "efg" WHERE "buz"=$1)'
+            ' "sq0" ON "abc"."bar"="sq0"."buz" WHERE "abc"."bar"=$2',
             sql,
         )
-        self.assertEqual({"param1": "buz", "param2": "bar"}, parameter.get_parameters())
-
-    def test_join_with_parameter_value_wrapper(self):
-        subquery = (
-            Query.from_(self.table_efg)
-            .select(self.table_efg.fiz, self.table_efg.buz)
-            .where(self.table_efg.buz == ParameterValueWrapper(Parameter(":buz"), "buz"))
-        )
-
-        q = (
-            Query.from_(self.table_abc)
-            .join(subquery)
-            .on(self.table_abc.bar == subquery.buz)
-            .select(self.table_abc.foo, subquery.fiz)
-            .where(self.table_abc.bar == ParameterValueWrapper(NamedParameter("bar"), "bar"))
-        )
-
-        parameter = NamedParameter()
-        sql = q.get_sql(parameter=parameter)
-        self.assertEqual(
-            'SELECT "abc"."foo","sq0"."fiz" FROM "abc" JOIN (SELECT "fiz","buz" FROM "efg" WHERE "buz"=:buz)'
-            ' "sq0" ON "abc"."bar"="sq0"."buz" WHERE "abc"."bar"=:bar',
-            sql,
-        )
-        self.assertEqual({":buz": "buz", "bar": "bar"}, parameter.get_parameters())
-
-    def test_pyformat_parameter(self):
-        q = Query.into(self.table_abc).columns("a", "b", "c").insert(1, 2.2, "foo")
-
-        parameter = PyformatParameter()
-        sql = q.get_sql(parameter=parameter)
-        self.assertEqual(
-            'INSERT INTO "abc" ("a","b","c") VALUES (%(param1)s,%(param2)s,%(param3)s)', sql
-        )
-        self.assertEqual({"param1": 1, "param2": 2.2, "param3": "foo"}, parameter.get_parameters())
+        self.assertEqual(["buz", "bar"], parameterizer.values)
 
     def test_function_parameter(self):
         q = (
@@ -220,8 +185,34 @@ class ParametrizedTestsWithValues(unittest.TestCase):
             .select("*")
             .where(self.table_abc.category == Upper(ValueWrapper("foobar")))
         )
-        p = ListParameter("%s")
-        sql = q.get_sql(parameter=p)
-        self.assertEqual('SELECT * FROM "abc" WHERE "category"=UPPER(%s)', sql)
+        parameterizer = Parameterizer()
+        sql = q.get_sql(parameterizer=parameterizer)
+        self.assertEqual('SELECT * FROM "abc" WHERE "category"=UPPER(?)', sql)
 
-        self.assertEqual(["foobar"], p.get_parameters())
+        self.assertEqual(["foobar"], parameterizer.values)
+
+    def test_case_when_in_select(self):
+        q = Query.from_(self.table_abc).select(
+            Case().when(self.table_abc.category == "foobar", 1).else_(2)
+        )
+        parameterizer = Parameterizer()
+        sql = q.get_sql(parameterizer=parameterizer)
+        self.assertEqual('SELECT CASE WHEN "category"=? THEN ? ELSE ? END FROM "abc"', sql)
+        self.assertEqual(["foobar", 1, 2], parameterizer.values)
+
+    def test_case_when_in_where(self):
+        q = (
+            Query.from_(self.table_abc)
+            .select("*")
+            .where(
+                self.table_abc.category_int
+                > Case().when(self.table_abc.category == "foobar", 1).else_(2)
+            )
+        )
+        parameterizer = Parameterizer()
+        sql = q.get_sql(parameterizer=parameterizer)
+        self.assertEqual(
+            'SELECT * FROM "abc" WHERE "category_int">CASE WHEN "category"=? THEN ? ELSE ? END',
+            sql,
+        )
+        self.assertEqual(["foobar", 1, 2], parameterizer.values)

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from pypika import Field, Query, Table
-from pypika.terms import AtTimezone
+from pypika.terms import AtTimezone, Parameterizer, ValueWrapper
 
 
 class FieldAliasTests(TestCase):
@@ -49,3 +49,15 @@ class AtTimezoneTests(TestCase):
             'FROM "customers" JOIN "accounts" ON "customers"."account_id"="accounts"."account_id"',
             query.get_sql(with_namespace=True),
         )
+
+
+class ValueWrapperTests(TestCase):
+    def test_allow_parametrize(self):
+        value = ValueWrapper("foo")
+        self.assertEqual("'foo'", value.get_sql())
+
+        value = ValueWrapper("foo")
+        self.assertEqual("?", value.get_sql(parameterizer=Parameterizer()))
+
+        value = ValueWrapper("foo", allow_parametrize=False)
+        self.assertEqual("'foo'", value.get_sql(parameterizer=Parameterizer()))

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -43,7 +43,7 @@ class UpdateTests(unittest.TestCase):
 
     def test_update_with_none(self):
         q = Query.update("abc").set("foo", None)
-        self.assertEqual('UPDATE "abc" SET "foo"=null', str(q))
+        self.assertEqual('UPDATE "abc" SET "foo"=NULL', str(q))
 
     def test_update_from(self):
         from_table = Table("from_table")


### PR DESCRIPTION
This PR's main goal is to support query parametrization in tortoise-orm.

- Wraps query's offset and limit with `ValueWrapper` so they can be parametrized
- Refactors `Parameter` to be dialect-aware. The original version in Pypika requires the user to specify the correct placeholder for the dialect (`PyformatParameter`, `QmarkParameter`, etc.) which is contradictory to other features where pypika generates a correct SQL according to the chosen dialect. For tortoise purposes, it is much more convenient to delegate the responsibility of generating correct SQL to pypika as much as possible.
- Changes the behavior of `Parameter.get_sql` to avoid doing character escaping, type conversion, etc. if parametrization is used because database drivers usually do those things themselves for parametrized queries. Doing it twice causes subtle errors and extra latency.
- Introduces `Parameterizer` which replaces `ListParameter`, `DictParameter`, etc. This is mostly a refactoring change since the original code is quite convoluted and has questionable abstractions, e.g. `ListParameter` isn't really a parameter but a container for values, the `parameter` argument of `get_sql` isn't really a parameter but a container for values. This is change is making it harder to pull changes from pypika's upstream but I found it quite hard to use the original code for tortoise purposes.
- Adds missing whitespace for MSSQL when pagination without ordering.

I'll rebase the branch when this is going to be merged https://github.com/tortoise/tortoise-orm/pull/1776.