### PR TITLE
Implement Array parametrization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 0.3
 
-## 0.3.0
+### 0.3.1
+- `Array` can be parametrized
+
+### 0.3.0
 - Add `Parameterizer`
 - Uppdate `Parameter` to be dialect-aware
 - Remove `ListParameter`, `DictParameter`, `QmarkParameter`, etc.

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -210,7 +210,7 @@ class Term(Node):
 
     def isin(self, arg: list | tuple | set | "Term") -> "ContainsCriterion":
         if isinstance(arg, (list, tuple, set)):
-            return ContainsCriterion(self, Tuple(*[self.wrap_constant(value) for value in arg]))
+            return ContainsCriterion(self, Tuple(*arg))
         return ContainsCriterion(self, arg)
 
     def notin(self, arg: list | tuple | set | "Term") -> "ContainsCriterion":

--- a/pypika/terms.py
+++ b/pypika/terms.py
@@ -69,7 +69,7 @@ class Term(Node):
     @staticmethod
     def wrap_constant(
         val, wrapper_cls: Type["Term"] | None = None
-    ) -> ValueError | NodeT | "LiteralValue" | "Array" | "Tuple" | "ValueWrapper":
+    ) -> NodeT | "LiteralValue" | "Array" | "Tuple" | "ValueWrapper":
         """
         Used for wrapping raw inputs such as numbers in Criterions and Operator.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypika-tortoise"
-version = "0.3.0"
+version = "0.3.1"
 description = "Forked from pypika and streamline just for tortoise-orm"
 authors = ["long2ice <long2ice@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_tuples.py
+++ b/tests/test_tuples.py
@@ -2,7 +2,7 @@ import unittest
 
 from pypika import Array, Bracket, PostgreSQLQuery, Query, Table, Tables, Tuple
 from pypika.functions import Coalesce, NullIf, Sum
-from pypika.terms import Field
+from pypika.terms import Field, Parameterizer, Star
 
 
 class TupleTests(unittest.TestCase):
@@ -148,6 +148,13 @@ class ArrayTests(unittest.TestCase):
 
         q = Query.from_(tb).select(Array(tb.col).as_("different_name"))
         self.assertEqual(str(q), 'SELECT ["col"] "different_name" FROM "tb"')
+
+    def test_parametrization(self):
+        q = Query.from_(self.table_abc).select(Star()).where(self.table_abc.f == Array(1, 2, 3))
+
+        parameterizer = Parameterizer()
+        sql = q.get_sql(parameterizer=parameterizer)
+        self.assertEqual('SELECT * FROM "abc" WHERE "f"=?', sql)
 
 
 class BracketTests(unittest.TestCase):


### PR DESCRIPTION
This PR allows the whole `Array` to be parametrized as other values. This is required to finish the parametrization work in tortoise-orm. Basically, this changes the parametrization behavior from parametrizing individual elements of an `Array` to replacing the whole `Array` with a placeholder.

It also cuts a new release 0.3.1