### PR TITLE
Add QueryBuilder.get_parameterized_sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.3
 
+### 0.3.2
+- Added `QueryBuilder.get_parameterized_sql`
+
 ### 0.3.1
 - `Array` can be parametrized
 

--- a/README.md
+++ b/README.md
@@ -5,25 +5,20 @@
 [![image](https://github.com/tortoise/pypika-tortoise/workflows/pypi/badge.svg)](https://github.com/tortoise/pypika-tortoise/actions?query=workflow:pypi)
 [![image](https://github.com/tortoise/pypika-tortoise/workflows/ci/badge.svg)](https://github.com/tortoise/pypika-tortoise/actions?query=workflow:ci)
 
-Forked from [pypika](https://github.com/kayak/pypika) and streamline just for tortoise-orm.
+Forked from [pypika](https://github.com/kayak/pypika) and adapted just for tortoise-orm.
 
 ## Why forked?
 
-The original repo include many databases that tortoise-orm don't need, and which aims to be a perfect sql builder and
-should consider more compatibilities, but tortoise-orm is not, and we need add new features and update it ourselves.
+The original repository includes many databases that Tortoise ORM doesn’t require. It aims to be a comprehensive SQL builder with broad compatibility, but that’s not the goal for Tortoise ORM. Having it forked makes it easier to add new features for Tortoise.
 
-## What change?
+## What changed?
 
-Delete many codes that tortoise-orm don't need, and add features just tortoise-orm considers to.
-
-## What affect tortoise-orm?
-
-Nothing, because this repo keeps the original struct and code.
+Deleted unnecessary code that Tortoise ORM doesn’t require, and added features tailored specifically for Tortoise ORM.
 
 ## ThanksTo
 
-- [pypika](https://github.com/kayak/pypika), a python SQL query builder that exposes the full richness of the SQL
-  language using a syntax that reflects the resulting query.
+- [pypika](https://github.com/kayak/pypika), a Python SQL query builder that exposes the full expressiveness of SQL, 
+using a syntax that mirrors the resulting query structure.
 
 ## License
 

--- a/pypika/queries.py
+++ b/pypika/queries.py
@@ -16,6 +16,7 @@ from pypika.terms import (
     Index,
     Node,
     Order,
+    Parameterizer,
     PeriodCriterion,
     Rollup,
     Star,
@@ -1562,6 +1563,16 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
             + clause.get_sql(subquery=False, with_alias=False, **kwargs)
             + ") "
             for clause in self._with
+        )
+
+    def get_parameterized_sql(self, **kwargs) -> tuple[str, list]:
+        """
+        Returns a tuple containing the query string and a list of parameters
+        """
+        parameterizer = kwargs.pop("parameterizer", Parameterizer())
+        return (
+            self.get_sql(parameterizer=parameterizer, **kwargs),
+            parameterizer.values,
         )
 
     def _distinct_sql(self, **kwargs: Any) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypika-tortoise"
-version = "0.3.1"
+version = "0.3.2"
 description = "Forked from pypika and streamline just for tortoise-orm"
 authors = ["long2ice <long2ice@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -11,7 +11,7 @@ from pypika.dialects import (
     SQLLiteQuery,
     SQLLiteQueryBuilder,
 )
-from pypika.queries import CreateQueryBuilder, DropQueryBuilder, QueryBuilder
+from pypika.queries import CreateQueryBuilder, DropQueryBuilder, QueryBuilder, Table
 
 
 class QueryTablesTests(unittest.TestCase):
@@ -209,3 +209,10 @@ class QueryBuilderTests(unittest.TestCase):
         self.assertIsNot(qb._on_conflict_fields, qb2._on_conflict_fields)
         self.assertEqual(qb._on_conflict_do_updates, qb2._on_conflict_do_updates)
         self.assertIsNot(qb._on_conflict_do_updates, qb2._on_conflict_do_updates)
+
+    def test_get_parameterized_sql(self):
+        table = Table("abc")
+        q = QueryBuilder().from_(table).select("foo").where(table.bar == 1)
+        sql, params = q.get_parameterized_sql()
+        self.assertEqual('SELECT "foo" FROM "abc" WHERE "bar"=?', sql)
+        self.assertEqual([1], params)


### PR DESCRIPTION
The title. This should simplify parametrization of queries in Tortoise. Basically this allows us to shift the logic of parametrization to pypika.

It also improves the language of README.