### PR TITLE
Replace kwargs with SqlContext in get_sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## 0.5
+
+### 0.5.0
+
+- Replace `get_sql` kwargs with `SqlContext` to improve performance
+
 ## 0.4
 
 ### 0.4.0

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ The original repository includes many databases that Tortoise ORM doesn’t requ
 
 ## What changed?
 
-Deleted unnecessary code that Tortoise ORM doesn’t require, and added features tailored specifically for Tortoise ORM.
+Deleted unnecessary code that Tortoise ORM doesn’t require, added features tailored specifically for Tortoise ORM,
+and modified to improve query generation performance.
 
 ## ThanksTo
 
-- [pypika](https://github.com/kayak/pypika), a Python SQL query builder that exposes the full expressiveness of SQL, 
+- [pypika](https://github.com/kayak/pypika), a Python SQL query builder that exposes the full expressiveness of SQL,
 using a syntax that mirrors the resulting query structure.
 
 ## License

--- a/pypika_tortoise/__init__.py
+++ b/pypika_tortoise/__init__.py
@@ -1,3 +1,4 @@
+from .context import SqlContext
 from .dialects import MSSQLQuery, MySQLQuery, OracleQuery, PostgreSQLQuery, SQLLiteQuery
 from .enums import DatePart, Dialects, JoinType, Order
 from .exceptions import (

--- a/pypika_tortoise/context.py
+++ b/pypika_tortoise/context.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class SqlContext:
+    """Represents the context for get_sql() methods to determine how to render SQL."""
+
     quote_char: str
     secondary_quote_char: str
     alias_quote_char: str

--- a/pypika_tortoise/context.py
+++ b/pypika_tortoise/context.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SqlContext:
+    quote_char: str
+    secondary_quote_char: str
+    alias_quote_char: str
+    dialect: "Dialects"
+    as_keyword: bool = False
+    subquery: bool = False
+    with_alias: bool = False
+    with_namespace: bool = False
+    subcriterion: bool = False
+    parameterizer: "Parameterizer" | None = None
+    groupby_alias: bool = True
+    orderby_alias: bool = True
+
+    def copy(self, **kwargs) -> SqlContext:
+        return SqlContext(
+            quote_char=kwargs.get("quote_char", self.quote_char),
+            secondary_quote_char=kwargs.get("secondary_quote_char", self.secondary_quote_char),
+            alias_quote_char=kwargs.get("alias_quote_char", self.alias_quote_char),
+            dialect=kwargs.get("dialect", self.dialect),
+            as_keyword=kwargs.get("as_keyword", self.as_keyword),
+            subquery=kwargs.get("subquery", self.subquery),
+            with_alias=kwargs.get("with_alias", self.with_alias),
+            with_namespace=kwargs.get("with_namespace", self.with_namespace),
+            subcriterion=kwargs.get("subcriterion", self.subcriterion),
+            parameterizer=kwargs.get("parameterizer", self.parameterizer),
+            groupby_alias=kwargs.get("groupby_alias", self.groupby_alias),
+            orderby_alias=kwargs.get("orderby_alias", self.orderby_alias),
+        )
+
+
+from .enums import Dialects  # noqa: E402
+
+DEFAULT_SQL_CONTEXT = SqlContext(
+    quote_char='"',
+    secondary_quote_char="'",
+    alias_quote_char=None,
+    as_keyword=False,
+    dialect=Dialects.SQLITE,
+)
+
+from .terms import Parameterizer  # noqa: E402

--- a/pypika_tortoise/context.py
+++ b/pypika_tortoise/context.py
@@ -40,7 +40,7 @@ from .enums import Dialects  # noqa: E402
 DEFAULT_SQL_CONTEXT = SqlContext(
     quote_char='"',
     secondary_quote_char="'",
-    alias_quote_char=None,
+    alias_quote_char="",
     as_keyword=False,
     dialect=Dialects.SQLITE,
 )

--- a/pypika_tortoise/dialects/mssql.py
+++ b/pypika_tortoise/dialects/mssql.py
@@ -15,13 +15,14 @@ class MSSQLQuery(Query):
     Defines a query class for use with Microsoft SQL Server.
     """
 
+    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.MSSQL)
+
     @classmethod
     def _builder(cls, **kwargs: Any) -> "MSSQLQueryBuilder":
         return MSSQLQueryBuilder(**kwargs)
 
 
 class MSSQLQueryBuilder(QueryBuilder):
-    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.MSSQL)
     QUERY_CLS = MSSQLQuery
 
     def __init__(self, **kwargs: Any) -> None:
@@ -73,7 +74,7 @@ class MSSQLQueryBuilder(QueryBuilder):
 
     def get_sql(self, ctx: SqlContext | None = None) -> str:
         if not ctx:
-            ctx = self.SQL_CONTEXT
+            ctx = MSSQLQuery.SQL_CONTEXT
         # MSSQL does not support group by a field alias.
         # Note: set directly in kwargs as they are re-used down the tree in the case of subqueries!
         ctx = ctx.copy(groupby_alias=False)

--- a/pypika_tortoise/dialects/mssql.py
+++ b/pypika_tortoise/dialects/mssql.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+from ..context import DEFAULT_SQL_CONTEXT, SqlContext
 from ..enums import Dialects
 from ..exceptions import QueryException
 from ..queries import Query, QueryBuilder
@@ -20,10 +21,11 @@ class MSSQLQuery(Query):
 
 
 class MSSQLQueryBuilder(QueryBuilder):
+    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.MSSQL)
     QUERY_CLS = MSSQLQuery
 
     def __init__(self, **kwargs: Any) -> None:
-        super().__init__(dialect=Dialects.MSSQL, **kwargs)
+        super().__init__(**kwargs)
         self._top: int | None = None
 
     @builder
@@ -45,44 +47,45 @@ class MSSQLQueryBuilder(QueryBuilder):
         # Overridden to provide a more domain-specific API for T-SQL users
         self._limit = cast(ValueWrapper, self.wrap_constant(limit))
 
-    def _offset_sql(self, **kwargs) -> str:
+    def _offset_sql(self, ctx: SqlContext) -> str:
         order_by = ""
         if not self._orderbys:
             order_by = " ORDER BY (SELECT 0)"
         return order_by + " OFFSET {offset} ROWS".format(
-            offset=self._offset.get_sql(**kwargs) if self._offset is not None else 0
+            offset=self._offset.get_sql(ctx) if self._offset is not None else 0
         )
 
-    def _limit_sql(self, **kwargs) -> str:
+    def _limit_sql(self, ctx: SqlContext) -> str:
         if self._limit is None:
             return ""
-        return " FETCH NEXT {limit} ROWS ONLY".format(limit=self._limit.get_sql(**kwargs))
+        return " FETCH NEXT {limit} ROWS ONLY".format(limit=self._limit.get_sql(ctx))
 
-    def _apply_pagination(self, querystring: str, **kwargs) -> str:
+    def _apply_pagination(self, querystring: str, ctx: SqlContext) -> str:
         # Note: Overridden as MSSQL specifies offset before the fetch next limit
         if self._limit is not None or self._offset:
             # Offset has to be present if fetch next is specified in a MSSQL query
-            querystring += self._offset_sql(**kwargs)
+            querystring += self._offset_sql(ctx)
 
         if self._limit is not None:
-            querystring += self._limit_sql(**kwargs)
+            querystring += self._limit_sql(ctx)
 
         return querystring
 
-    def get_sql(self, *args: Any, **kwargs: Any) -> str:
+    def get_sql(self, ctx: SqlContext | None = None) -> str:
+        if not ctx:
+            ctx = self.SQL_CONTEXT
         # MSSQL does not support group by a field alias.
         # Note: set directly in kwargs as they are re-used down the tree in the case of subqueries!
-        kwargs["groupby_alias"] = False
-        return super().get_sql(*args, **kwargs)
+        ctx = ctx.copy(groupby_alias=False)
+        return super().get_sql(ctx)
 
     def _top_sql(self) -> str:
         return "TOP ({}) ".format(self._top) if self._top else ""
 
-    def _select_sql(self, **kwargs: Any) -> str:
+    def _select_sql(self, ctx: SqlContext) -> str:
+        ctx = ctx.copy(with_alias=True, subquery=True)
         return "SELECT {distinct}{top}{select}".format(
             top=self._top_sql(),
             distinct="DISTINCT " if self._distinct else "",
-            select=",".join(
-                term.get_sql(with_alias=True, subquery=True, **kwargs) for term in self._selects
-            ),
+            select=",".join(term.get_sql(ctx) for term in self._selects),
         )

--- a/pypika_tortoise/dialects/mysql.py
+++ b/pypika_tortoise/dialects/mysql.py
@@ -4,6 +4,7 @@ import json
 from datetime import time
 from typing import Any, cast
 
+from ..context import DEFAULT_SQL_CONTEXT, SqlContext
 from ..enums import Dialects
 from ..queries import Query, QueryBuilder, Table
 from ..terms import ValueWrapper
@@ -25,8 +26,8 @@ class MySQLQuery(Query):
 
 
 class MySQLValueWrapper(ValueWrapper):
-    def get_value_sql(self, **kwargs: Any) -> str:
-        quote_char = kwargs.get("secondary_quote_char") or ""
+    def get_value_sql(self, ctx: SqlContext) -> str:
+        quote_char = ctx.secondary_quote_char or ""
         if isinstance(value := self.value, str):
             value = value.replace(quote_char, quote_char * 2)
             value = value.replace("\\", "\\\\")
@@ -37,60 +38,55 @@ class MySQLValueWrapper(ValueWrapper):
         elif isinstance(value, (dict, list)):
             value = format_quotes(json.dumps(value), quote_char)
             return value.replace("\\", "\\\\")
-        return super().get_value_sql(**kwargs)
+        return super().get_value_sql(ctx)
 
 
 class MySQLQueryBuilder(QueryBuilder):
-    QUOTE_CHAR = "`"
+    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.MYSQL, quote_char="`")
     QUERY_CLS = MySQLQuery
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(
-            dialect=Dialects.MYSQL,
             wrapper_cls=MySQLValueWrapper,
             wrap_set_operation_queries=False,
             **kwargs,
         )
         self._modifiers: list[str] = []
 
-    def _on_conflict_sql(self, **kwargs: Any) -> str:
-        kwargs["alias_quote_char"] = (
-            self.ALIAS_QUOTE_CHAR
-            if self.QUERY_ALIAS_QUOTE_CHAR is None
-            else self.QUERY_ALIAS_QUOTE_CHAR
+    def _on_conflict_sql(self, ctx: SqlContext) -> str:
+        ctx = ctx.copy(
+            as_keyword=True,
         )
-        kwargs["as_keyword"] = True
-        querystring = format_alias_sql("", self.alias, **kwargs)
-        return querystring
+        return format_alias_sql("", self.alias, ctx)
 
-    def get_sql(self, **kwargs: Any) -> str:  # type:ignore[override]
-        self._set_kwargs_defaults(kwargs)
-        querystring = super().get_sql(**kwargs)
+    def get_sql(self, ctx: SqlContext | None = None) -> str:
+        ctx = ctx or self.SQL_CONTEXT
+        querystring = super().get_sql(ctx)
         if querystring and self._update_table:
             if self._orderbys:
-                querystring += self._orderby_sql(**kwargs)
+                querystring += self._orderby_sql(ctx)
             if self._limit:
-                querystring += self._limit_sql()
+                querystring += self._limit_sql(ctx)
         return querystring
 
-    def _on_conflict_action_sql(self, **kwargs: Any) -> str:
-        kwargs.pop("with_namespace", None)
+    def _on_conflict_action_sql(self, ctx: SqlContext) -> str:
+        on_conflict_ctx = ctx.copy(with_namespace=False)
         if len(self._on_conflict_do_updates) > 0:
             updates = []
             for field, value in self._on_conflict_do_updates:
                 if value:
                     updates.append(
                         "{field}={value}".format(
-                            field=field.get_sql(**kwargs),
-                            value=value.get_sql(**kwargs),
+                            field=field.get_sql(on_conflict_ctx),
+                            value=value.get_sql(on_conflict_ctx),
                         )
                     )
                 else:
                     updates.append(
                         "{field}={alias}.{value}".format(
-                            field=field.get_sql(**kwargs),
-                            alias=format_quotes(self.alias, self.QUOTE_CHAR),
-                            value=field.get_sql(**kwargs),
+                            field=field.get_sql(on_conflict_ctx),
+                            alias=format_quotes(self.alias, ctx.quote_char),
+                            value=field.get_sql(on_conflict_ctx),
                         )
                     )
             action_sql = " ON DUPLICATE KEY UPDATE {updates}".format(updates=",".join(updates))
@@ -107,23 +103,22 @@ class MySQLQueryBuilder(QueryBuilder):
         """
         self._modifiers.append(value)
 
-    def _select_sql(self, **kwargs: Any) -> str:
+    def _select_sql(self, ctx: SqlContext) -> str:
         """
         Overridden function to generate the SELECT part of the SQL statement,
         with the addition of the a modifier if present.
         """
+        ctx = ctx.copy(with_alias=True, subquery=True)
         return "SELECT {distinct}{modifier}{select}".format(
             distinct="DISTINCT " if self._distinct else "",
             modifier="{} ".format(" ".join(self._modifiers)) if self._modifiers else "",
-            select=",".join(
-                term.get_sql(with_alias=True, subquery=True, **kwargs) for term in self._selects
-            ),
+            select=",".join(term.get_sql(ctx) for term in self._selects),
         )
 
-    def _insert_sql(self, **kwargs: Any) -> str:
+    def _insert_sql(self, ctx: SqlContext) -> str:
         insert_table = cast(Table, self._insert_table)
         return "INSERT {ignore}INTO {table}".format(
-            table=insert_table.get_sql(**kwargs),
+            table=insert_table.get_sql(ctx),
             ignore="IGNORE " if self._on_conflict_do_nothing else "",
         )
 
@@ -143,23 +138,26 @@ class MySQLLoadQueryBuilder:
     def into(self, table: str | Table) -> MySQLLoadQueryBuilder:  # type:ignore[return]
         self._into_table = table if isinstance(table, Table) else Table(table)
 
-    def get_sql(self, *args: Any, **kwargs: Any) -> str:
+    def get_sql(self, ctx: SqlContext | None = None) -> str:
+        if not ctx:
+            ctx = MySQLQueryBuilder.SQL_CONTEXT
+
         querystring = ""
         if self._load_file and self._into_table:
-            querystring += self._load_file_sql(**kwargs)
-            querystring += self._into_table_sql(**kwargs)
-            querystring += self._options_sql(**kwargs)
+            querystring += self._load_file_sql(ctx)
+            querystring += self._into_table_sql(ctx)
+            querystring += self._options_sql(ctx)
 
         return querystring
 
-    def _load_file_sql(self, **kwargs: Any) -> str:
+    def _load_file_sql(self, ctx: SqlContext) -> str:
         return "LOAD DATA LOCAL INFILE '{}'".format(self._load_file)
 
-    def _into_table_sql(self, **kwargs: Any) -> str:
+    def _into_table_sql(self, ctx: SqlContext) -> str:
         table = cast(Table, self._into_table)
-        return " INTO TABLE `{}`".format(table.get_sql(**kwargs))
+        return " INTO TABLE {}".format(table.get_sql(ctx))
 
-    def _options_sql(self, **kwargs: Any) -> str:
+    def _options_sql(self, ctx: SqlContext) -> str:
         return " FIELDS TERMINATED BY ','"
 
     def __str__(self) -> str:

--- a/pypika_tortoise/dialects/mysql.py
+++ b/pypika_tortoise/dialects/mysql.py
@@ -16,6 +16,8 @@ class MySQLQuery(Query):
     Defines a query class for use with MySQL.
     """
 
+    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.MYSQL, quote_char="`")
+
     @classmethod
     def _builder(cls, **kwargs: Any) -> "MySQLQueryBuilder":
         return MySQLQueryBuilder(**kwargs)
@@ -42,7 +44,6 @@ class MySQLValueWrapper(ValueWrapper):
 
 
 class MySQLQueryBuilder(QueryBuilder):
-    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.MYSQL, quote_char="`")
     QUERY_CLS = MySQLQuery
 
     def __init__(self, **kwargs: Any) -> None:
@@ -60,7 +61,7 @@ class MySQLQueryBuilder(QueryBuilder):
         return format_alias_sql("", self.alias, ctx)
 
     def get_sql(self, ctx: SqlContext | None = None) -> str:
-        ctx = ctx or self.SQL_CONTEXT
+        ctx = ctx or MySQLQuery.SQL_CONTEXT
         querystring = super().get_sql(ctx)
         if querystring and self._update_table:
             if self._orderbys:
@@ -140,7 +141,7 @@ class MySQLLoadQueryBuilder:
 
     def get_sql(self, ctx: SqlContext | None = None) -> str:
         if not ctx:
-            ctx = MySQLQueryBuilder.SQL_CONTEXT
+            ctx = MySQLQuery.SQL_CONTEXT
 
         querystring = ""
         if self._load_file and self._into_table:

--- a/pypika_tortoise/dialects/oracle.py
+++ b/pypika_tortoise/dialects/oracle.py
@@ -12,13 +12,14 @@ class OracleQuery(Query):
     Defines a query class for use with Oracle.
     """
 
+    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.ORACLE, alias_quote_char='"')
+
     @classmethod
     def _builder(cls, **kwargs: Any) -> "OracleQueryBuilder":
         return OracleQueryBuilder(**kwargs)
 
 
 class OracleQueryBuilder(QueryBuilder):
-    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.ORACLE, alias_quote_char='"')
     QUERY_CLS = OracleQuery
 
     def __init__(self, **kwargs: Any) -> None:
@@ -26,7 +27,7 @@ class OracleQueryBuilder(QueryBuilder):
 
     def get_sql(self, ctx: SqlContext | None = None) -> str:
         if not ctx:
-            ctx = self.SQL_CONTEXT
+            ctx = OracleQuery.SQL_CONTEXT
         # Oracle does not support group by a field alias.
         ctx = ctx.copy(groupby_alias=False)
         return super().get_sql(ctx)

--- a/pypika_tortoise/dialects/postgresql.py
+++ b/pypika_tortoise/dialects/postgresql.py
@@ -24,13 +24,14 @@ class PostgreSQLQuery(Query):
     Defines a query class for use with PostgreSQL.
     """
 
+    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.POSTGRESQL, alias_quote_char='"')
+
     @classmethod
     def _builder(cls, **kwargs) -> "PostgreSQLQueryBuilder":
         return PostgreSQLQueryBuilder(**kwargs)
 
 
 class PostgreSQLQueryBuilder(QueryBuilder):
-    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.POSTGRESQL, alias_quote_char='"')
     QUERY_CLS = PostgreSQLQuery
 
     def __init__(self, **kwargs: Any) -> None:
@@ -155,7 +156,7 @@ class PostgreSQLQueryBuilder(QueryBuilder):
         has_reference_to_foreign_table = self._foreign_table
         has_update_from = self._update_table and self._from
 
-        ctx = ctx or self.SQL_CONTEXT
+        ctx = ctx or PostgreSQLQuery.SQL_CONTEXT
         ctx = ctx.copy(
             with_namespace=any(
                 [

--- a/pypika_tortoise/dialects/postgresql.py
+++ b/pypika_tortoise/dialects/postgresql.py
@@ -75,9 +75,7 @@ class PostgreSQLQueryBuilder(QueryBuilder):
             elif isinstance(term, Function):
                 raise QueryException("Aggregate functions are not allowed in returning")
             else:
-                self._return_other(
-                    self.wrap_constant(term, self._wrapper_cls)  # type:ignore[arg-type]
-                )
+                self._return_other(self.wrap_constant(term, self._wrapper_cls))
 
     def _validate_returning_term(self, term: Term) -> None:
         for field in term.fields_():

--- a/pypika_tortoise/dialects/sqlite.py
+++ b/pypika_tortoise/dialects/sqlite.py
@@ -33,7 +33,7 @@ class SQLLiteQueryBuilder(QueryBuilder):
     def __init__(self, **kwargs) -> None:
         super().__init__(wrapper_cls=SQLLiteValueWrapper, **kwargs)
 
-    def get_sql(self, ctx: SqlContext | None = None) -> str:  # type:ignore[override]
+    def get_sql(self, ctx: SqlContext | None = None) -> str:
         ctx = ctx or SQLLiteQuery.SQL_CONTEXT
         if not (self._selects or self._insert_table or self._delete_from or self._update_table):
             return ""

--- a/pypika_tortoise/dialects/sqlite.py
+++ b/pypika_tortoise/dialects/sqlite.py
@@ -20,20 +20,21 @@ class SQLLiteQuery(Query):
     Defines a query class for use with Microsoft SQL Server.
     """
 
+    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.SQLITE)
+
     @classmethod
     def _builder(cls, **kwargs: Any) -> "SQLLiteQueryBuilder":
         return SQLLiteQueryBuilder(**kwargs)
 
 
 class SQLLiteQueryBuilder(QueryBuilder):
-    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.SQLITE)
     QUERY_CLS = SQLLiteQuery
 
     def __init__(self, **kwargs) -> None:
         super().__init__(wrapper_cls=SQLLiteValueWrapper, **kwargs)
 
     def get_sql(self, ctx: SqlContext | None = None) -> str:  # type:ignore[override]
-        ctx = ctx or self.SQL_CONTEXT
+        ctx = ctx or SQLLiteQuery.SQL_CONTEXT
         if not (self._selects or self._insert_table or self._delete_from or self._update_table):
             return ""
         if self._insert_table and not (self._selects or self._values):

--- a/pypika_tortoise/dialects/sqlite.py
+++ b/pypika_tortoise/dialects/sqlite.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..context import DEFAULT_SQL_CONTEXT, SqlContext
 from ..enums import Dialects
 from ..queries import Query, QueryBuilder
 from ..terms import ValueWrapper
 
 
 class SQLLiteValueWrapper(ValueWrapper):
-    def get_value_sql(self, **kwargs: Any) -> str:
+    def get_value_sql(self, ctx: SqlContext) -> str:
         if isinstance(self.value, bool):
             return "1" if self.value else "0"
-        return super().get_value_sql(**kwargs)
+        return super().get_value_sql(ctx)
 
 
 class SQLLiteQuery(Query):
@@ -25,13 +26,14 @@ class SQLLiteQuery(Query):
 
 
 class SQLLiteQueryBuilder(QueryBuilder):
+    SQL_CONTEXT = DEFAULT_SQL_CONTEXT.copy(dialect=Dialects.SQLITE)
     QUERY_CLS = SQLLiteQuery
 
     def __init__(self, **kwargs) -> None:
-        super().__init__(dialect=Dialects.SQLITE, wrapper_cls=SQLLiteValueWrapper, **kwargs)
+        super().__init__(wrapper_cls=SQLLiteValueWrapper, **kwargs)
 
-    def get_sql(self, **kwargs: Any) -> str:  # type:ignore[override]
-        self._set_kwargs_defaults(kwargs)
+    def get_sql(self, ctx: SqlContext | None = None) -> str:  # type:ignore[override]
+        ctx = ctx or self.SQL_CONTEXT
         if not (self._selects or self._insert_table or self._delete_from or self._update_table):
             return ""
         if self._insert_table and not (self._selects or self._values):
@@ -45,40 +47,42 @@ class SQLLiteQueryBuilder(QueryBuilder):
         has_reference_to_foreign_table = self._foreign_table
         has_update_from = self._update_table and self._from
 
-        kwargs["with_namespace"] = any(
-            [
-                has_joins,
-                has_multiple_from_clauses,
-                has_subquery_from_clause,
-                has_reference_to_foreign_table,
-                has_update_from,
-            ]
+        ctx = ctx.copy(
+            with_namespace=any(
+                [
+                    has_joins,
+                    has_multiple_from_clauses,
+                    has_subquery_from_clause,
+                    has_reference_to_foreign_table,
+                    has_update_from,
+                ]
+            ),
         )
         if self._update_table:
             if self._with:
-                querystring = self._with_sql(**kwargs)
+                querystring = self._with_sql(ctx)
             else:
                 querystring = ""
 
-            querystring += self._update_sql(**kwargs)
+            querystring += self._update_sql(ctx)
 
-            querystring += self._set_sql(**kwargs)
+            querystring += self._set_sql(ctx)
 
             if self._joins:
                 self._from.append(self._update_table.as_(self._update_table.get_table_name() + "_"))
 
             if self._from:
-                querystring += self._from_sql(**kwargs)
+                querystring += self._from_sql(ctx)
             if self._joins:
-                querystring += " " + " ".join(join.get_sql(**kwargs) for join in self._joins)
+                querystring += " " + " ".join(join.get_sql(ctx) for join in self._joins)
 
             if self._wheres:
-                querystring += self._where_sql(**kwargs)
+                querystring += self._where_sql(ctx)
 
             if self._orderbys:
-                querystring += self._orderby_sql(**kwargs)
+                querystring += self._orderby_sql(ctx)
             if self._limit:
-                querystring += self._limit_sql()
+                querystring += self._limit_sql(ctx)
         else:
-            querystring = super().get_sql(**kwargs)
+            querystring = super().get_sql(ctx=ctx)
         return querystring

--- a/pypika_tortoise/enums.py
+++ b/pypika_tortoise/enums.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Any
 
 
 class Arithmetic(Enum):
@@ -86,7 +85,7 @@ class SqlType:
     def __call__(self, length: int) -> "SqlTypeLength":
         return SqlTypeLength(self.name, length)
 
-    def get_sql(self, **kwargs: Any) -> str:
+    def get_sql(self, ctx: "SqlContext") -> str:
         return "{name}".format(name=self.name)
 
 
@@ -95,7 +94,7 @@ class SqlTypeLength:
         self.name = name
         self.length = length
 
-    def get_sql(self, **kwargs: Any) -> str:
+    def get_sql(self, ctx: "SqlContext") -> str:
         return "{name}({length})".format(name=self.name, length=self.length)
 
 
@@ -141,3 +140,6 @@ class JSONOperators(Enum):
     GET_TEXT_VALUE = "->>"
     GET_PATH_JSON_VALUE = "#>"
     GET_PATH_TEXT_VALUE = "#>>"
+
+
+from .context import SqlContext  # noqa: E402

--- a/pypika_tortoise/queries.py
+++ b/pypika_tortoise/queries.py
@@ -5,6 +5,7 @@ from copy import copy
 from functools import reduce
 from typing import TYPE_CHECKING, Any, Sequence, Type, cast, overload
 
+from .context import DEFAULT_SQL_CONTEXT, SqlContext
 from .enums import Dialects, JoinType, SetOperation
 from .exceptions import JoinException, QueryException, RollupException, SetOperationException
 from .terms import (
@@ -59,7 +60,7 @@ class Selectable(Node):
     def get_table_name(self) -> str:
         return self.alias
 
-    def get_sql(self, **kwargs: Any) -> str:
+    def get_sql(self, ctx: SqlContext) -> str:
         raise NotImplementedError()
 
 
@@ -73,10 +74,10 @@ class AliasedQuery(Selectable):
         self.name = name
         self.query = query
 
-    def get_sql(self, **kwargs: Any) -> str:
+    def get_sql(self, ctx: SqlContext) -> str:
         if self.query is None:
             return self.name
-        return self.query.get_sql(**kwargs)
+        return self.query.get_sql(ctx)
 
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, AliasedQuery) and self.name == other.name
@@ -111,13 +112,13 @@ class Schema:
     def __getattr__(self, item: str) -> "Table":
         return Table(item, schema=self)
 
-    def get_sql(self, quote_char: str | None = None, **kwargs: Any) -> str:
+    def get_sql(self, ctx: SqlContext) -> str:
         # FIXME escape
-        schema_sql = format_quotes(self._name, quote_char)
+        schema_sql = format_quotes(self._name, ctx.quote_char)
 
         if self._parent is not None:
             return "{parent}.{schema}".format(
-                parent=self._parent.get_sql(quote_char=quote_char, **kwargs),
+                parent=self._parent.get_sql(ctx),
                 schema=schema_sql,
             )
 
@@ -178,26 +179,23 @@ class Table(Selectable):
     def get_table_name(self) -> str:
         return self.alias or self._table_name
 
-    def get_sql(self, **kwargs: Any) -> str:
-        quote_char = kwargs.get("quote_char")
+    def get_sql(self, ctx: SqlContext) -> str:
         # FIXME escape
-        table_sql = format_quotes(self._table_name, quote_char)
+        table_sql = format_quotes(self._table_name, ctx.quote_char)
 
         if self._schema is not None:
-            table_sql = "{schema}.{table}".format(
-                schema=self._schema.get_sql(**kwargs), table=table_sql
-            )
+            table_sql = "{schema}.{table}".format(schema=self._schema.get_sql(ctx), table=table_sql)
 
         if self._for:
             table_sql = "{table} FOR {criterion}".format(
-                table=table_sql, criterion=self._for.get_sql(**kwargs)
+                table=table_sql, criterion=self._for.get_sql(ctx)
             )
         elif self._for_portion:
             table_sql = "{table} FOR PORTION OF {criterion}".format(
-                table=table_sql, criterion=self._for_portion.get_sql(**kwargs)
+                table=table_sql, criterion=self._for_portion.get_sql(ctx)
             )
 
-        return format_alias_sql(table_sql, self.alias, **kwargs)
+        return format_alias_sql(table_sql, self.alias, ctx)
 
     @builder
     def for_(self, temporal_criterion: Criterion) -> "Self":  # type:ignore[return]
@@ -216,7 +214,7 @@ class Table(Selectable):
         self._for_portion = period_criterion
 
     def __str__(self) -> str:
-        return self.get_sql(quote_char='"')
+        return self.get_sql(DEFAULT_SQL_CONTEXT)
 
     def __eq__(self, other: Any) -> bool:
         return (
@@ -310,33 +308,29 @@ class Column:
             default if default is None or isinstance(default, Term) else ValueWrapper(default)
         )
 
-    def get_name_sql(self, **kwargs: Any) -> str:
-        quote_char = kwargs.get("quote_char")
-
+    def get_name_sql(self, ctx: SqlContext) -> str:
         column_sql = "{name}".format(
-            name=format_quotes(self.name, quote_char),
+            name=format_quotes(self.name, ctx.quote_char),
         )
 
         return column_sql
 
-    def get_sql(self, **kwargs: Any) -> str:
+    def get_sql(self, ctx: SqlContext) -> str:
         column_sql = "{name}{type}{nullable}{default}".format(
-            name=self.get_name_sql(**kwargs),
+            name=self.get_name_sql(ctx),
             type=" {}".format(self.type) if self.type else "",
             nullable=(
                 " {}".format("NULL" if self.nullable else "NOT NULL")
                 if self.nullable is not None
                 else ""
             ),
-            default=(
-                " {}".format("DEFAULT " + self.default.get_sql(**kwargs)) if self.default else ""
-            ),
+            default=(" {}".format("DEFAULT " + self.default.get_sql(ctx)) if self.default else ""),
         )
 
         return column_sql
 
     def __str__(self) -> str:
-        return self.get_sql(quote_char='"')
+        return self.get_sql(DEFAULT_SQL_CONTEXT)
 
 
 def make_columns(*names: tuple[str, str] | str) -> list[Column]:
@@ -369,13 +363,11 @@ class PeriodFor:
         )
         self.end_column = end_column if isinstance(end_column, Column) else Column(end_column)
 
-    def get_sql(self, **kwargs: Any) -> str:
-        quote_char = kwargs.get("quote_char")
-
+    def get_sql(self, ctx: SqlContext) -> str:
         period_for_sql = "PERIOD FOR {name} ({start_column_name},{end_column_name})".format(
-            name=format_quotes(self.name, quote_char),
-            start_column_name=self.start_column.get_name_sql(**kwargs),
-            end_column_name=self.end_column.get_name_sql(**kwargs),
+            name=format_quotes(self.name, ctx.quote_char),
+            start_column_name=self.start_column.get_name_sql(ctx),
+            end_column_name=self.end_column.get_name_sql(ctx),
         )
 
         return period_for_sql
@@ -597,25 +589,23 @@ class _SetOperation(Selectable, Term):  # type:ignore[misc]
         return self.minus(other)
 
     def __str__(self) -> str:
-        return self.get_sql()
+        return self.get_sql(DEFAULT_SQL_CONTEXT)
 
-    def get_sql(self, with_alias: bool = False, subquery: bool = False, **kwargs: Any) -> str:
+    def get_sql(self, ctx: SqlContext) -> str:
         set_operation_template = " {type} {query_string}"
 
-        kwargs.setdefault("dialect", self.base_query.dialect)
-        # This initializes the quote char based on the base query, which could be a dialect specific query class
-        # This might be overridden if quote_char is set explicitly in kwargs
-        kwargs.setdefault("quote_char", self.base_query.QUOTE_CHAR)
-
-        base_querystring = self.base_query.get_sql(
-            subquery=self.base_query.wrap_set_operation_queries, **kwargs
+        # Default to the base query's dialect and quote_char
+        ctx = ctx.copy(
+            dialect=self.base_query.dialect,
+            quote_char=self.base_query.SQL_CONTEXT.quote_char,
+            parameterizer=ctx.parameterizer,
         )
+        set_ctx = ctx.copy(subquery=self.base_query.wrap_set_operation_queries)
+        base_querystring = self.base_query.get_sql(set_ctx)
 
         querystring = base_querystring
         for set_operation, set_operation_query in self._set_operation:
-            set_operation_querystring = set_operation_query.get_sql(
-                subquery=self.base_query.wrap_set_operation_queries, **kwargs
-            )
+            set_operation_querystring = set_operation_query.get_sql(set_ctx)
 
             if len(self.base_query._selects) != len(set_operation_query._selects):
                 raise SetOperationException(
@@ -630,24 +620,24 @@ class _SetOperation(Selectable, Term):  # type:ignore[misc]
             )
 
         if self._orderbys:
-            querystring += self._orderby_sql(**kwargs)
+            querystring += self._orderby_sql(ctx)
 
-        querystring += self._limit_sql(**kwargs)
-        querystring += self._offset_sql(**kwargs)
+        querystring += self._limit_sql(ctx)
+        querystring += self._offset_sql(ctx)
 
-        if subquery:
-            querystring = "({query})".format(query=querystring, **kwargs)
+        if ctx.subquery:
+            querystring = "({query})".format(query=querystring)
 
-        if with_alias:
+        if ctx.with_alias:
             return format_alias_sql(
                 querystring,
                 self.alias or self._table_name,  # type:ignore[arg-type]
-                **kwargs,
+                ctx,
             )
 
         return querystring
 
-    def _orderby_sql(self, quote_char: str | None = None, **kwargs: Any) -> str:
+    def _orderby_sql(self, ctx: SqlContext) -> str:
         """
         Produces the ORDER BY part of the query.  This is a list of fields and possibly their directionality, ASC or
         DESC. The clauses are stored in the query under self._orderbys as a list of tuples containing the field and
@@ -660,9 +650,9 @@ class _SetOperation(Selectable, Term):  # type:ignore[misc]
         selected_aliases = {s.alias for s in self.base_query._selects}
         for field, directionality in self._orderbys:
             term = (
-                format_quotes(field.alias, quote_char)
+                format_quotes(field.alias, ctx.quote_char)
                 if field.alias and field.alias in selected_aliases
-                else field.get_sql(quote_char=quote_char, **kwargs)
+                else field.get_sql(ctx)
             )
 
             clauses.append(
@@ -673,15 +663,15 @@ class _SetOperation(Selectable, Term):  # type:ignore[misc]
 
         return " ORDER BY {orderby}".format(orderby=",".join(clauses))
 
-    def _offset_sql(self, **kwargs) -> str:
+    def _offset_sql(self, ctx: SqlContext) -> str:
         if self._offset is None:
             return ""
-        return " OFFSET {offset}".format(offset=self._offset.get_sql(**kwargs))
+        return " OFFSET {offset}".format(offset=self._offset.get_sql(ctx))
 
-    def _limit_sql(self, **kwargs) -> str:
+    def _limit_sql(self, ctx: SqlContext) -> str:
         if self._limit is None:
             return ""
-        return " LIMIT {limit}".format(limit=self._limit.get_sql(**kwargs))
+        return " LIMIT {limit}".format(limit=self._limit.get_sql(ctx))
 
 
 class QueryBuilder(Selectable, Term):  # type:ignore[misc]
@@ -690,19 +680,14 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
     state to be branched immutably.
     """
 
-    QUOTE_CHAR = '"'
-    SECONDARY_QUOTE_CHAR = "'"
-    ALIAS_QUOTE_CHAR: str | None = None
-    QUERY_ALIAS_QUOTE_CHAR: str | None = None
+    SQL_CONTEXT: SqlContext = DEFAULT_SQL_CONTEXT
     QUERY_CLS = Query
 
     def __init__(
         self,
-        dialect: Dialects | None = None,
         wrap_set_operation_queries: bool = True,
         wrapper_cls: Type[ValueWrapper] = ValueWrapper,
         immutable: bool = True,
-        as_keyword: bool = False,
     ) -> None:
         super().__init__(None)  # type:ignore[arg-type]
 
@@ -747,8 +732,6 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
         self._subquery_count = 0
         self._foreign_table = False
 
-        self.dialect = dialect
-        self.as_keyword = as_keyword
         self.wrap_set_operation_queries = wrap_set_operation_queries
 
         self._wrapper_cls = wrapper_cls
@@ -817,7 +800,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
             return Field(term, table=self._insert_table)
         return None
 
-    def _on_conflict_sql(self, **kwargs: Any) -> str:
+    def _on_conflict_sql(self, ctx: SqlContext) -> str:
         if not self._on_conflict_do_nothing and len(self._on_conflict_do_updates) == 0:
             if not self._on_conflict_fields:
                 return ""
@@ -828,38 +811,40 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
 
         conflict_query = " ON CONFLICT"
         if self._on_conflict_fields:
+            on_conflict_ctx = ctx.copy(with_alias=True)
             fields = [
-                f.get_sql(with_alias=True, **kwargs)  # type:ignore[union-attr]
+                f.get_sql(on_conflict_ctx)  # type:ignore[union-attr]
                 for f in self._on_conflict_fields
             ]
             conflict_query += " (" + ", ".join(fields) + ")"
 
         if self._on_conflict_wheres:
+            where_ctx = ctx.copy(subquery=True)
             conflict_query += " WHERE {where}".format(
-                where=self._on_conflict_wheres.get_sql(subquery=True, **kwargs)
+                where=self._on_conflict_wheres.get_sql(where_ctx)
             )
 
         return conflict_query
 
-    def _on_conflict_action_sql(self, **kwargs: Any) -> str:
-        kwargs.pop("with_namespace", None)
+    def _on_conflict_action_sql(self, ctx: SqlContext) -> str:
+        ctx = ctx.copy(with_namespace=False)
         if self._on_conflict_do_nothing:
             return " DO NOTHING"
         elif len(self._on_conflict_do_updates) > 0:
             updates = []
+            value_ctx = ctx.copy(with_namespace=True)
             for field, value in self._on_conflict_do_updates:
                 if value:
                     updates.append(
                         "{field}={value}".format(
-                            field=field.get_sql(**kwargs),
-                            value=value.get_sql(with_namespace=True, **kwargs),
+                            field=field.get_sql(ctx), value=value.get_sql(value_ctx)
                         )
                     )
                 else:
                     updates.append(
                         "{field}=EXCLUDED.{value}".format(
-                            field=field.get_sql(**kwargs),
-                            value=field.get_sql(**kwargs),
+                            field=field.get_sql(ctx),
+                            value=field.get_sql(ctx),
                         )
                     )
             action_sql = " DO UPDATE SET {updates}".format(updates=",".join(updates))  # nosec:B608
@@ -867,7 +852,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
             if self._on_conflict_do_update_wheres:
                 action_sql += " WHERE {where}".format(
                     where=self._on_conflict_do_update_wheres.get_sql(
-                        subquery=True, with_namespace=True, **kwargs
+                        ctx.copy(subquery=True, with_namespace=True)
                     )
                 )
             return action_sql
@@ -1288,8 +1273,8 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
         return self.slice(item)
 
     @staticmethod
-    def _list_aliases(field_set: Sequence[Field], quote_char: str | None = None) -> list[str]:
-        return [field.alias or field.get_sql(quote_char=quote_char) for field in field_set]
+    def _list_aliases(field_set: Sequence[Field], ctx: SqlContext) -> list[str]:
+        return [field.alias or field.get_sql(ctx) for field in field_set]
 
     def _select_field_str(self, term: str) -> None:
         if 0 == len(self._from):
@@ -1387,7 +1372,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
             )
 
     def __str__(self) -> str:
-        return self.get_sql(dialect=self.dialect)
+        return self.get_sql(self.SQL_CONTEXT)
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -1401,15 +1386,10 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
     def __hash__(self) -> int:
         return hash(self.alias) + sum(hash(clause) for clause in self._from)
 
-    def _set_kwargs_defaults(self, kwargs: dict) -> None:
-        kwargs.setdefault("quote_char", self.QUOTE_CHAR)
-        kwargs.setdefault("secondary_quote_char", self.SECONDARY_QUOTE_CHAR)
-        kwargs.setdefault("alias_quote_char", self.ALIAS_QUOTE_CHAR)
-        kwargs.setdefault("as_keyword", self.as_keyword)
-        kwargs.setdefault("dialect", self.dialect)
+    def get_sql(self, ctx: SqlContext | None = None) -> str:
+        if not ctx:
+            ctx = self.SQL_CONTEXT
 
-    def get_sql(self, with_alias: bool = False, subquery: bool = False, **kwargs: Any) -> str:
-        self._set_kwargs_defaults(kwargs)
         if not (self._selects or self._insert_table or self._delete_from or self._update_table):
             return ""
         if self._insert_table and not (self._selects or self._values):
@@ -1423,166 +1403,172 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
         has_reference_to_foreign_table = self._foreign_table
         has_update_from = self._update_table and self._from
 
-        kwargs["with_namespace"] = any(
-            [
-                has_joins,
-                has_multiple_from_clauses,
-                has_subquery_from_clause,
-                has_reference_to_foreign_table,
-                has_update_from,
-            ]
+        ctx = ctx.copy(
+            with_namespace=any(
+                [
+                    has_joins,
+                    has_multiple_from_clauses,
+                    has_subquery_from_clause,
+                    has_reference_to_foreign_table,
+                    has_update_from,
+                ]
+            )
         )
 
         if self._update_table:
             if self._with:
-                querystring = self._with_sql(**kwargs)
+                querystring = self._with_sql(ctx)
             else:
                 querystring = ""
 
-            querystring += self._update_sql(**kwargs)
+            querystring += self._update_sql(ctx)
 
             if self._joins:
-                querystring += " " + " ".join(join.get_sql(**kwargs) for join in self._joins)
+                querystring += " " + " ".join(join.get_sql(ctx) for join in self._joins)
 
-            querystring += self._set_sql(**kwargs)
+            querystring += self._set_sql(ctx)
 
             if self._from:
-                querystring += self._from_sql(**kwargs)
+                querystring += self._from_sql(ctx)
 
             if self._wheres:
-                querystring += self._where_sql(**kwargs)
+                querystring += self._where_sql(ctx)
 
             return querystring
 
         if self._delete_from:
-            querystring = self._delete_sql(**kwargs)
+            querystring = self._delete_sql(ctx)
 
         elif not self._select_into and self._insert_table:
             if self._with:
-                querystring = self._with_sql(**kwargs)
+                querystring = self._with_sql(ctx)
             else:
                 querystring = ""
 
             if self._replace:
-                querystring += self._replace_sql(**kwargs)
+                querystring += self._replace_sql(ctx)
             else:
-                querystring += self._insert_sql(**kwargs)
+                querystring += self._insert_sql(ctx)
 
             if self._columns:
-                querystring += self._columns_sql(**kwargs)
+                querystring += self._columns_sql(ctx)
 
             if self._values:
-                querystring += self._values_sql(**kwargs)
+                querystring += self._values_sql(ctx)
                 if self._on_conflict:
-                    querystring += self._on_conflict_sql(**kwargs)
-                    querystring += self._on_conflict_action_sql(**kwargs)
+                    querystring += self._on_conflict_sql(ctx)
+                    querystring += self._on_conflict_action_sql(ctx)
                 return querystring
             else:
-                querystring += " " + self._select_sql(**kwargs)
+                querystring += " " + self._select_sql(ctx)
 
         else:
             if self._with:
-                querystring = self._with_sql(**kwargs)
+                querystring = self._with_sql(ctx)
             else:
                 querystring = ""
 
-            querystring += self._select_sql(**kwargs)
+            querystring += self._select_sql(ctx)
 
             if self._insert_table:
-                querystring += self._into_sql(**kwargs)
+                querystring += self._into_sql(ctx)
 
         if self._from:
-            querystring += self._from_sql(**kwargs)
+            querystring += self._from_sql(ctx)
 
         if self._force_indexes:
-            querystring += self._force_index_sql(**kwargs)
+            querystring += self._force_index_sql(ctx)
 
         if self._use_indexes:
-            querystring += self._use_index_sql(**kwargs)
+            querystring += self._use_index_sql(ctx)
 
         if self._joins:
-            querystring += " " + " ".join(join.get_sql(**kwargs) for join in self._joins)
+            querystring += " " + " ".join(join.get_sql(ctx) for join in self._joins)
 
         if self._prewheres:
-            querystring += self._prewhere_sql(**kwargs)
+            querystring += self._prewhere_sql(ctx)
 
         if self._wheres:
-            querystring += self._where_sql(**kwargs)
+            querystring += self._where_sql(ctx)
 
         if self._groupbys:
-            querystring += self._group_sql(**kwargs)
+            querystring += self._group_sql(ctx)
             if self._mysql_rollup:
                 querystring += self._rollup_sql()
 
         if self._havings:
-            querystring += self._having_sql(**kwargs)
+            querystring += self._having_sql(ctx)
 
         if self._orderbys:
-            querystring += self._orderby_sql(**kwargs)
+            querystring += self._orderby_sql(ctx)
 
-        querystring = self._apply_pagination(querystring, **kwargs)
+        querystring = self._apply_pagination(querystring, ctx)
 
         if self._for_update:
-            querystring += self._for_update_sql(**kwargs)
+            querystring += self._for_update_sql(ctx)
 
-        if subquery:
+        if ctx.subquery:
             querystring = "({query})".format(query=querystring)
         if self._on_conflict:
-            querystring += self._on_conflict_sql(**kwargs)
-            querystring += self._on_conflict_action_sql(**kwargs)
-        if with_alias:
-            kwargs["alias_quote_char"] = (
-                self.ALIAS_QUOTE_CHAR
-                if self.QUERY_ALIAS_QUOTE_CHAR is None
-                else self.QUERY_ALIAS_QUOTE_CHAR
-            )
-            return format_alias_sql(querystring, self.alias, **kwargs)
+            querystring += self._on_conflict_sql(ctx)
+            querystring += self._on_conflict_action_sql(ctx)
+        if ctx.with_alias:
+            return format_alias_sql(querystring, self.alias, ctx)
 
         return querystring
 
-    def _apply_pagination(self, querystring: str, **kwargs) -> str:
-        querystring += self._limit_sql(**kwargs)
-        querystring += self._offset_sql(**kwargs)
+    def _apply_pagination(self, querystring: str, ctx: SqlContext) -> str:
+        querystring += self._limit_sql(ctx)
+        querystring += self._offset_sql(ctx)
         return querystring
 
-    def _with_sql(self, **kwargs: Any) -> str:
+    def _with_sql(self, ctx: SqlContext) -> str:
         all_alias = [with_.alias for with_ in self._with]
         recursive = False
         for with_ in self._with:
             if with_.query.from_ in all_alias:  # type:ignore[operator,union-attr]
                 recursive = True
                 break
+
+        as_ctx = ctx.copy(subquery=False, with_alias=False)
         return f"WITH {'RECURSIVE ' if recursive else ''}" + ",".join(
             clause.alias
             + (
-                "(" + ",".join([term.get_sql(**kwargs) for term in clause.terms]) + ")"
+                "(" + ",".join([term.get_sql(ctx) for term in clause.terms]) + ")"
                 if clause.terms
                 else ""
             )
             + " AS ("
-            + clause.get_sql(subquery=False, with_alias=False, **kwargs)
+            + clause.get_sql(as_ctx)
             + ") "
             for clause in self._with
         )
 
-    def get_parameterized_sql(self, **kwargs) -> tuple[str, list]:
+    def get_parameterized_sql(self, ctx: SqlContext | None = None) -> tuple[str, list]:
         """
         Returns a tuple containing the query string and a list of parameters
         """
-        parameterizer = kwargs.pop("parameterizer", Parameterizer())
+        if not ctx:
+            ctx = self.SQL_CONTEXT
+
+        if not ctx.parameterizer:
+            ctx = ctx.copy(parameterizer=Parameterizer())
+
         return (
-            self.get_sql(parameterizer=parameterizer, **kwargs),
-            parameterizer.values,
+            self.get_sql(ctx),
+            ctx.parameterizer.values,
         )
 
-    def _distinct_sql(self, **kwargs: Any) -> str:
+    def _distinct_sql(self, ctx: SqlContext) -> str:
         return "DISTINCT " if self._distinct else ""
 
-    def _for_update_sql(self, **kwargs) -> str:
+    def _for_update_sql(self, ctx: SqlContext) -> str:
         if self._for_update:
             for_update = " FOR UPDATE"
             if self._for_update_of:
-                for_update += f' OF {", ".join([Table(item).get_sql(**kwargs) for item in self._for_update_of])}'
+                for_update += (
+                    f' OF {", ".join([Table(item).get_sql(ctx) for item in self._for_update_of])}'
+                )
             if self._for_update_nowait:
                 for_update += " NOWAIT"
             elif self._for_update_skip_locked:
@@ -1592,88 +1578,80 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
 
         return for_update
 
-    def _select_sql(self, **kwargs: Any) -> str:
+    def _select_sql(self, ctx: SqlContext) -> str:
+        select_ctx = ctx.copy(subquery=True, with_alias=True)
         return "SELECT {distinct}{select}".format(
-            distinct=self._distinct_sql(**kwargs),
-            select=",".join(
-                term.get_sql(with_alias=True, subquery=True, **kwargs) for term in self._selects
-            ),
+            distinct=self._distinct_sql(ctx),
+            select=",".join(term.get_sql(select_ctx) for term in self._selects),
         )
 
-    def _insert_sql(self, **kwargs: Any) -> str:
-        table = self._insert_table.get_sql(**kwargs)  # type:ignore[union-attr]
+    def _insert_sql(self, ctx: SqlContext) -> str:
+        table = self._insert_table.get_sql(ctx)  # type:ignore[union-attr]
         return f"INSERT INTO {table}"
 
-    def _replace_sql(self, **kwargs: Any) -> str:
-        table = self._insert_table.get_sql(**kwargs)  # type:ignore[union-attr]
+    def _replace_sql(self, ctx: SqlContext) -> str:
+        table = self._insert_table.get_sql(ctx)  # type:ignore[union-attr]
         return f"REPLACE INTO {table}"
 
     @staticmethod
-    def _delete_sql(**kwargs: Any) -> str:
+    def _delete_sql(ctx: SqlContext) -> str:
         return "DELETE"
 
-    def _update_sql(self, **kwargs: Any) -> str:
-        table = self._update_table.get_sql(**kwargs)  # type:ignore[union-attr]
+    def _update_sql(self, ctx: SqlContext) -> str:
+        table = self._update_table.get_sql(ctx)  # type:ignore[union-attr]
         return f"UPDATE {table}"
 
-    def _columns_sql(self, with_namespace: bool = False, **kwargs: Any) -> str:
+    def _columns_sql(self, ctx: SqlContext) -> str:
         """
         SQL for Columns clause for INSERT queries
-        :param with_namespace:
-            Remove from kwargs, never format the column terms with namespaces since only one table can be inserted into
         """
-        return " ({columns})".format(
-            columns=",".join(term.get_sql(with_namespace=False, **kwargs) for term in self._columns)
-        )
+        # Remove from ctx, never format the column terms with namespaces since only one table can be inserted into
+        ctx = ctx.copy(with_namespace=False)
+        return " ({columns})".format(columns=",".join(term.get_sql(ctx) for term in self._columns))
 
-    def _values_sql(self, **kwargs: Any) -> str:
+    def _values_sql(self, ctx: SqlContext) -> str:
+        values_ctx = ctx.copy(subquery=True, with_alias=True)
         return " VALUES ({values})".format(
             values="),(".join(
-                ",".join(term.get_sql(with_alias=True, subquery=True, **kwargs) for term in row)
-                for row in self._values
+                ",".join(term.get_sql(values_ctx) for term in row) for row in self._values
             )
         )
 
-    def _into_sql(self, **kwargs: Any) -> str:
+    def _into_sql(self, ctx: SqlContext) -> str:
+        into_ctx = ctx.copy(with_alias=False)
         return " INTO {table}".format(
-            table=self._insert_table.get_sql(with_alias=False, **kwargs),  # type:ignore[union-attr]
+            table=self._insert_table.get_sql(into_ctx),  # type:ignore[union-attr]
         )
 
-    def _from_sql(self, with_namespace: bool = False, **kwargs: Any) -> str:
+    def _from_sql(self, ctx: SqlContext) -> str:
+        from_ctx = ctx.copy(subquery=True, with_alias=True)
         return " FROM {selectable}".format(
-            selectable=",".join(
-                clause.get_sql(subquery=True, with_alias=True, **kwargs) for clause in self._from
-            )
+            selectable=",".join(clause.get_sql(from_ctx) for clause in self._from)
         )
 
-    def _force_index_sql(self, **kwargs: Any) -> str:
+    def _force_index_sql(self, ctx: SqlContext) -> str:
         return " FORCE INDEX ({indexes})".format(
-            indexes=",".join(index.get_sql(**kwargs) for index in self._force_indexes),
+            indexes=",".join(index.get_sql(ctx) for index in self._force_indexes),
         )
 
-    def _use_index_sql(self, **kwargs: Any) -> str:
+    def _use_index_sql(self, ctx: SqlContext) -> str:
         return " USE INDEX ({indexes})".format(
-            indexes=",".join(index.get_sql(**kwargs) for index in self._use_indexes),
+            indexes=",".join(index.get_sql(ctx) for index in self._use_indexes),
         )
 
-    def _prewhere_sql(self, quote_char: str | None = None, **kwargs: Any) -> str:
+    def _prewhere_sql(self, ctx: SqlContext) -> str:
+        prewhere_sql = ctx.copy(subquery=True)
         prewheres = cast(QueryBuilder, self._prewheres)
-        return " PREWHERE {prewhere}".format(
-            prewhere=prewheres.get_sql(quote_char=quote_char, subquery=True, **kwargs)
-        )
+        return " PREWHERE {prewhere}".format(prewhere=prewheres.get_sql(prewhere_sql))
 
-    def _where_sql(self, quote_char: str | None = None, **kwargs: Any) -> str:
+    def _where_sql(self, ctx: SqlContext) -> str:
+        where_ctx = ctx.copy(subquery=True)
         wheres = cast(QueryBuilder, self._wheres)
-        return " WHERE {where}".format(
-            where=wheres.get_sql(quote_char=quote_char, subquery=True, **kwargs)
-        )
+        return " WHERE {where}".format(where=wheres.get_sql(where_ctx))
 
     def _group_sql(
         self,
-        quote_char: str | None = None,
-        alias_quote_char: str | None = None,
-        groupby_alias: bool = True,
-        **kwargs: Any,
+        ctx: SqlContext,
     ) -> str:
         """
         Produces the GROUP BY part of the query.  This is a list of fields. The clauses are stored in the query under
@@ -1688,27 +1666,15 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
         selected_aliases = {s.alias for s in self._selects}
         for field in self._groupbys:
             if (alias := field.alias) and alias in selected_aliases:
-                if groupby_alias:
-                    clauses.append(format_quotes(alias, alias_quote_char or quote_char))
+                if ctx.groupby_alias:
+                    clauses.append(format_quotes(alias, ctx.alias_quote_char or ctx.quote_char))
                 else:
                     for select in self._selects:
                         if select.alias == alias:
-                            clauses.append(
-                                select.get_sql(
-                                    quote_char=quote_char,
-                                    alias_quote_char=alias_quote_char,
-                                    **kwargs,
-                                )
-                            )
+                            clauses.append(select.get_sql(ctx))
                             break
             else:
-                clauses.append(
-                    field.get_sql(
-                        quote_char=quote_char,
-                        alias_quote_char=alias_quote_char,
-                        **kwargs,
-                    )
-                )
+                clauses.append(field.get_sql(ctx))
 
         sql = " GROUP BY {groupby}".format(groupby=",".join(clauses))
 
@@ -1719,10 +1685,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
 
     def _orderby_sql(
         self,
-        quote_char: str | None = None,
-        alias_quote_char: str | None = None,
-        orderby_alias: bool = True,
-        **kwargs: Any,
+        ctx: SqlContext,
     ) -> str:
         """
         Produces the ORDER BY part of the query.  This is a list of fields and possibly their directionality, ASC or
@@ -1738,11 +1701,9 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
         selected_aliases = {s.alias for s in self._selects}
         for field, directionality in self._orderbys:
             term = (
-                format_quotes(field.alias, alias_quote_char or quote_char)
-                if orderby_alias and field.alias and field.alias in selected_aliases
-                else field.get_sql(
-                    quote_char=quote_char, alias_quote_char=alias_quote_char, **kwargs
-                )
+                format_quotes(field.alias, ctx.alias_quote_char or ctx.quote_char)
+                if ctx.orderby_alias and field.alias and field.alias in selected_aliases
+                else field.get_sql(ctx)
             )
 
             clauses.append(
@@ -1756,26 +1717,27 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
     def _rollup_sql(self) -> str:
         return " WITH ROLLUP"
 
-    def _having_sql(self, quote_char: str | None = None, **kwargs: Any) -> str:
-        having = self._havings.get_sql(quote_char=quote_char, **kwargs)  # type:ignore[union-attr]
+    def _having_sql(self, ctx: SqlContext) -> str:
+        having = self._havings.get_sql(ctx)  # type:ignore[union-attr]
         return f" HAVING {having}"
 
-    def _offset_sql(self, **kwargs) -> str:
+    def _offset_sql(self, ctx: SqlContext) -> str:
         if self._offset is None:
             return ""
-        return " OFFSET {offset}".format(offset=self._offset.get_sql(**kwargs))
+        return " OFFSET {offset}".format(offset=self._offset.get_sql(ctx))
 
-    def _limit_sql(self, **kwargs) -> str:
+    def _limit_sql(self, ctx: SqlContext) -> str:
         if self._limit is None:
             return ""
-        return " LIMIT {limit}".format(limit=self._limit.get_sql(**kwargs))
+        return " LIMIT {limit}".format(limit=self._limit.get_sql(ctx))
 
-    def _set_sql(self, **kwargs: Any) -> str:
+    def _set_sql(self, ctx: SqlContext) -> str:
+        field_ctx = ctx.copy(with_namespace=False)
         return " SET {set}".format(
             set=",".join(
                 "{field}={value}".format(
-                    field=field.get_sql(**dict(kwargs, with_namespace=False)),
-                    value=value.get_sql(**kwargs),
+                    field=field.get_sql(field_ctx),
+                    value=value.get_sql(ctx),
                 )
                 for field, value in self._updates
             )
@@ -1852,9 +1814,10 @@ class Join:
         self.item = item
         self.how = how
 
-    def get_sql(self, **kwargs: Any) -> str:
+    def get_sql(self, ctx: SqlContext) -> str:
+        join_ctx = ctx.copy(subquery=True, with_alias=True)
         sql = "JOIN {table}".format(
-            table=self.item.get_sql(subquery=True, with_alias=True, **kwargs),
+            table=self.item.get_sql(join_ctx),
         )
 
         if self.how.value:
@@ -1894,11 +1857,12 @@ class JoinOn(Join):
         self.criterion = criteria
         self.collate = collate
 
-    def get_sql(self, **kwargs: Any) -> str:
-        join_sql = super().get_sql(**kwargs)
+    def get_sql(self, ctx: SqlContext) -> str:
+        join_sql = super().get_sql(ctx)
+        criterion_ctx = ctx.copy(subquery=True)
         return "{join} ON {criterion}{collate}".format(
             join=join_sql,
-            criterion=self.criterion.get_sql(subquery=True, **kwargs),
+            criterion=self.criterion.get_sql(criterion_ctx),
             collate=" COLLATE {}".format(self.collate) if self.collate else "",
         )
 
@@ -1939,11 +1903,11 @@ class JoinUsing(Join):
         super().__init__(item, how)
         self.fields = fields
 
-    def get_sql(self, **kwargs: Any) -> str:
-        join_sql = super().get_sql(**kwargs)
+    def get_sql(self, ctx: SqlContext) -> str:
+        join_sql = super().get_sql(ctx)
         return "{join} USING ({fields})".format(
             join=join_sql,
-            fields=",".join(field.get_sql(**kwargs) for field in self.fields),
+            fields=",".join(field.get_sql(ctx) for field in self.fields),
         )
 
     def validate(self, _from: Sequence[Table], _joins: Sequence[Table]) -> None:
@@ -1974,9 +1938,7 @@ class CreateQueryBuilder:
     Query builder used to build CREATE queries.
     """
 
-    QUOTE_CHAR = '"'
-    SECONDARY_QUOTE_CHAR = "'"
-    ALIAS_QUOTE_CHAR: str | None = None
+    SQL_CONTEXT: SqlContext = DEFAULT_SQL_CONTEXT
     QUERY_CLS = Query
 
     def __init__(self, dialect: Dialects | None = None) -> None:
@@ -1991,11 +1953,6 @@ class CreateQueryBuilder:
         self._uniques: list[list[Column]] = []
         self._if_not_exists = False
         self.dialect = dialect
-
-    def _set_kwargs_defaults(self, kwargs: dict) -> None:
-        kwargs.setdefault("quote_char", self.QUOTE_CHAR)
-        kwargs.setdefault("secondary_quote_char", self.SECONDARY_QUOTE_CHAR)
-        kwargs.setdefault("dialect", self.dialect)
 
     @builder
     def create_table(self, table: Table | str) -> "Self":  # type:ignore[return]
@@ -2160,14 +2117,14 @@ class CreateQueryBuilder:
     def if_not_exists(self) -> "Self":  # type:ignore[return]
         self._if_not_exists = True
 
-    def get_sql(self, **kwargs: Any) -> str:
+    def get_sql(self, ctx: SqlContext | None) -> str:
         """
         Gets the sql statement string.
 
         :return: The create table statement.
         :rtype: str
         """
-        self._set_kwargs_defaults(kwargs)
+        ctx = ctx or self.SQL_CONTEXT
 
         if not self._create_table:
             return ""
@@ -2175,19 +2132,19 @@ class CreateQueryBuilder:
         if not self._columns and not self._as_select:
             return ""
 
-        create_table = self._create_table_sql(**kwargs)
+        create_table = self._create_table_sql(ctx)
 
         if self._as_select:
-            return create_table + self._as_select_sql(**kwargs)
+            return create_table + self._as_select_sql(ctx)
 
-        body = self._body_sql(**kwargs)
-        table_options = self._table_options_sql(**kwargs)
+        body = self._body_sql(ctx)
+        table_options = self._table_options_sql(ctx)
 
         return "{create_table} ({body}){table_options}".format(
             create_table=create_table, body=body, table_options=table_options
         )
 
-    def _create_table_sql(self, **kwargs: Any) -> str:
+    def _create_table_sql(self, ctx: SqlContext) -> str:
         table_type = ""
         if self._temporary:
             table_type = "TEMPORARY "
@@ -2201,10 +2158,10 @@ class CreateQueryBuilder:
         return "CREATE {table_type}TABLE {if_not_exists}{table}".format(
             table_type=table_type,
             if_not_exists=if_not_exists,
-            table=self._create_table.get_sql(**kwargs),  # type:ignore[attr-defined,union-attr]
+            table=self._create_table.get_sql(ctx),  # type:ignore[attr-defined,union-attr]
         )
 
-    def _table_options_sql(self, **kwargs) -> str:
+    def _table_options_sql(self, ctx: SqlContext) -> str:
         table_options = ""
 
         if self._with_system_versioning:
@@ -2212,44 +2169,44 @@ class CreateQueryBuilder:
 
         return table_options
 
-    def _column_clauses(self, **kwargs) -> list[str]:
-        return [column.get_sql(**kwargs) for column in self._columns]
+    def _column_clauses(self, ctx: SqlContext) -> list[str]:
+        return [column.get_sql(ctx) for column in self._columns]
 
-    def _period_for_clauses(self, **kwargs) -> list[str]:
-        return [period_for.get_sql(**kwargs) for period_for in self._period_fors]
+    def _period_for_clauses(self, ctx: SqlContext) -> list[str]:
+        return [period_for.get_sql(ctx) for period_for in self._period_fors]
 
-    def _unique_key_clauses(self, **kwargs) -> list[str]:
+    def _unique_key_clauses(self, ctx: SqlContext) -> list[str]:
         return [
             "UNIQUE ({unique})".format(
-                unique=",".join(column.get_name_sql(**kwargs) for column in unique)
+                unique=",".join(column.get_name_sql(ctx) for column in unique)
             )
             for unique in self._uniques
         ]
 
-    def _primary_key_clause(self, **kwargs) -> str:
+    def _primary_key_clause(self, ctx: SqlContext) -> str:
         columns = ",".join(
-            column.get_name_sql(**kwargs) for column in self._primary_key  # type:ignore[union-attr]
+            column.get_name_sql(ctx) for column in self._primary_key  # type:ignore[union-attr]
         )
         return f"PRIMARY KEY ({columns})"
 
-    def _body_sql(self, **kwargs) -> str:
-        clauses = self._column_clauses(**kwargs)
-        clauses += self._period_for_clauses(**kwargs)
-        clauses += self._unique_key_clauses(**kwargs)
+    def _body_sql(self, ctx: SqlContext) -> str:
+        clauses = self._column_clauses(ctx)
+        clauses += self._period_for_clauses(ctx)
+        clauses += self._unique_key_clauses(ctx)
 
         # Primary keys
         if self._primary_key:
-            clauses.append(self._primary_key_clause(**kwargs))
+            clauses.append(self._primary_key_clause(ctx))
 
         return ",".join(clauses)
 
-    def _as_select_sql(self, **kwargs: Any) -> str:
+    def _as_select_sql(self, ctx: SqlContext) -> str:
         return " AS ({query})".format(
-            query=self._as_select.get_sql(**kwargs),  # type:ignore[union-attr]
+            query=self._as_select.get_sql(ctx),  # type:ignore[union-attr]
         )
 
     def __str__(self) -> str:
-        return self.get_sql()
+        return self.get_sql(self.SQL_CONTEXT)
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -2260,28 +2217,20 @@ class DropQueryBuilder:
     Query builder used to build DROP queries.
     """
 
-    QUOTE_CHAR = '"'
-    SECONDARY_QUOTE_CHAR = "'"
-    ALIAS_QUOTE_CHAR: str | None = None
+    SQL_CONTEXT = DEFAULT_SQL_CONTEXT
     QUERY_CLS = Query
 
-    def __init__(self, dialect: Dialects | None = None) -> None:
+    def __init__(self) -> None:
         self._drop_table: Table | None = None
         self._if_exists: bool | None = None
-        self.dialect = dialect
 
-    def _set_kwargs_defaults(self, kwargs: dict) -> None:
-        kwargs.setdefault("quote_char", self.QUOTE_CHAR)
-        kwargs.setdefault("secondary_quote_char", self.SECONDARY_QUOTE_CHAR)
-        kwargs.setdefault("dialect", self.dialect)
-
-    def get_sql(self, **kwargs: Any) -> str:
-        self._set_kwargs_defaults(kwargs)
+    def get_sql(self, ctx: SqlContext | None = None) -> str:
+        ctx = ctx or self.SQL_CONTEXT
 
         if not self._drop_table:
             return ""
 
-        querystring = self._drop_table_sql(**kwargs)
+        querystring = self._drop_table_sql(ctx)
 
         return querystring
 
@@ -2296,16 +2245,16 @@ class DropQueryBuilder:
     def if_exists(self) -> "Self":  # type:ignore[return]
         self._if_exists = True
 
-    def _drop_table_sql(self, **kwargs: Any) -> str:
+    def _drop_table_sql(self, ctx: SqlContext) -> str:
         if_exists = "IF EXISTS " if self._if_exists else ""
         drop_table = cast(Table, self._drop_table)
         return "DROP TABLE {if_exists}{table}".format(
             if_exists=if_exists,
-            table=drop_table.get_sql(**kwargs),
+            table=drop_table.get_sql(ctx),
         )
 
     def __str__(self) -> str:
-        return self.get_sql()
+        return self.get_sql(self.SQL_CONTEXT)
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/pypika_tortoise/queries.py
+++ b/pypika_tortoise/queries.py
@@ -386,6 +386,8 @@ class Query:
     This class is immutable.
     """
 
+    SQL_CONTEXT: SqlContext = DEFAULT_SQL_CONTEXT
+
     @classmethod
     def _builder(cls, **kwargs: Any) -> "QueryBuilder":
         return QueryBuilder(**kwargs)
@@ -597,7 +599,7 @@ class _SetOperation(Selectable, Term):  # type:ignore[misc]
         # Default to the base query's dialect and quote_char
         ctx = ctx.copy(
             dialect=self.base_query.dialect,
-            quote_char=self.base_query.SQL_CONTEXT.quote_char,
+            quote_char=self.base_query.QUERY_CLS.SQL_CONTEXT.quote_char,
             parameterizer=ctx.parameterizer,
         )
         set_ctx = ctx.copy(subquery=self.base_query.wrap_set_operation_queries)
@@ -680,7 +682,6 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
     state to be branched immutably.
     """
 
-    SQL_CONTEXT: SqlContext = DEFAULT_SQL_CONTEXT
     QUERY_CLS = Query
 
     def __init__(
@@ -1372,7 +1373,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
             )
 
     def __str__(self) -> str:
-        return self.get_sql(self.SQL_CONTEXT)
+        return self.get_sql(self.QUERY_CLS.SQL_CONTEXT)
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -1388,7 +1389,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
 
     def get_sql(self, ctx: SqlContext | None = None) -> str:
         if not ctx:
-            ctx = self.SQL_CONTEXT
+            ctx = self.QUERY_CLS.SQL_CONTEXT
 
         if not (self._selects or self._insert_table or self._delete_from or self._update_table):
             return ""
@@ -1549,7 +1550,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
         Returns a tuple containing the query string and a list of parameters
         """
         if not ctx:
-            ctx = self.SQL_CONTEXT
+            ctx = self.QUERY_CLS.SQL_CONTEXT
 
         if not ctx.parameterizer:
             ctx = ctx.copy(parameterizer=Parameterizer())
@@ -1938,7 +1939,6 @@ class CreateQueryBuilder:
     Query builder used to build CREATE queries.
     """
 
-    SQL_CONTEXT: SqlContext = DEFAULT_SQL_CONTEXT
     QUERY_CLS = Query
 
     def __init__(self, dialect: Dialects | None = None) -> None:
@@ -2124,7 +2124,7 @@ class CreateQueryBuilder:
         :return: The create table statement.
         :rtype: str
         """
-        ctx = ctx or self.SQL_CONTEXT
+        ctx = ctx or self.QUERY_CLS.SQL_CONTEXT
 
         if not self._create_table:
             return ""
@@ -2206,7 +2206,7 @@ class CreateQueryBuilder:
         )
 
     def __str__(self) -> str:
-        return self.get_sql(self.SQL_CONTEXT)
+        return self.get_sql(self.QUERY_CLS.SQL_CONTEXT)
 
     def __repr__(self) -> str:
         return self.__str__()
@@ -2254,7 +2254,7 @@ class DropQueryBuilder:
         )
 
     def __str__(self) -> str:
-        return self.get_sql(self.SQL_CONTEXT)
+        return self.get_sql(self.QUERY_CLS.SQL_CONTEXT)
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/pypika_tortoise/queries.py
+++ b/pypika_tortoise/queries.py
@@ -930,9 +930,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
             self._wheres.replace_table(current_table, new_table) if self._wheres else None
         )
         self._prewheres = (
-            self._prewheres.replace_table(current_table, new_table)  # type:ignore[assignment]
-            if self._prewheres
-            else None
+            self._prewheres.replace_table(current_table, new_table) if self._prewheres else None
         )
         self._groupbys = [
             groupby.replace_table(current_table, new_table) for groupby in self._groupbys
@@ -1076,7 +1074,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
         if self._prewheres:
             self._prewheres &= criterion
         else:
-            self._prewheres = criterion  # type:ignore[assignment]
+            self._prewheres = criterion
 
     @builder
     def where(self, criterion: Term | EmptyCriterion) -> "Self":  # type:ignore[return]
@@ -1086,7 +1084,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
             if not self._validate_table(criterion):
                 self._foreign_table = True
             if self._wheres:
-                self._wheres &= criterion  # type:ignore[assignment,operator]
+                self._wheres &= criterion  # type:ignore[operator]
             else:
                 self._wheres = criterion
         else:
@@ -1108,18 +1106,18 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
     @builder
     def having(self, criterion: Criterion) -> "Self":  # type:ignore[return]
         if self._havings:
-            self._havings &= criterion  # type:ignore[operator]
+            self._havings &= criterion
         else:
-            self._havings = criterion  # type:ignore[assignment]
+            self._havings = criterion
 
     @builder
     def groupby(self, *terms: str | int | Term) -> "Self":  # type:ignore[return]
         for term in terms:
             if isinstance(term, str):
-                term = Field(term, table=self._from[0])  # type:ignore[assignment]
+                term = Field(term, table=self._from[0])
             elif isinstance(term, int):
                 field = Field(str(term), table=self._from[0])
-                term = field.wrap_constant(term)  # type:ignore[assignment]
+                term = field.wrap_constant(term)
 
             self._groupbys.append(term)  # type:ignore[arg-type]
 
@@ -1153,7 +1151,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
 
         elif 0 < len(self._groupbys) and isinstance(self._groupbys[-1], Rollup):
             # If a rollup was added last, then append the new terms to the previous rollup
-            self._groupbys[-1].args += terms  # type:ignore[arg-type]
+            self._groupbys[-1].args += terms
 
         else:
             self._groupbys.append(Rollup(*terms))  # type:ignore[arg-type]
@@ -1557,7 +1555,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
 
         return (
             self.get_sql(ctx),
-            ctx.parameterizer.values,
+            ctx.parameterizer.values,  # type: ignore
         )
 
     def _distinct_sql(self, ctx: SqlContext) -> str:
@@ -2158,7 +2156,7 @@ class CreateQueryBuilder:
         return "CREATE {table_type}TABLE {if_not_exists}{table}".format(
             table_type=table_type,
             if_not_exists=if_not_exists,
-            table=self._create_table.get_sql(ctx),  # type:ignore[attr-defined,union-attr]
+            table=self._create_table.get_sql(ctx),  # type: ignore
         )
 
     def _table_options_sql(self, ctx: SqlContext) -> str:

--- a/pypika_tortoise/terms.py
+++ b/pypika_tortoise/terms.py
@@ -49,7 +49,7 @@ class Node:
 
 
 class Term(Node):
-    is_aggregate: bool | None = False  # type:ignore[assignment]
+    is_aggregate: bool | None = False
 
     def __init__(self, alias: str | None = None) -> None:
         self.alias = alias
@@ -139,7 +139,7 @@ class Term(Node):
         return self.isnull().negate()
 
     def bitwiseand(self, value: int) -> "BitwiseAndCriterion":
-        return BitwiseAndCriterion(self, self.wrap_constant(value))  # type:ignore[arg-type]
+        return BitwiseAndCriterion(self, self.wrap_constant(value))
 
     def gt(self, other: Any) -> "BasicCriterion":
         return self > other
@@ -157,54 +157,34 @@ class Term(Node):
         return self != other
 
     def glob(self, expr: str) -> "BasicCriterion":
-        return BasicCriterion(
-            Matching.glob, self, self.wrap_constant(expr)  # type:ignore[arg-type]
-        )
+        return BasicCriterion(Matching.glob, self, self.wrap_constant(expr))
 
     def like(self, expr: str) -> "BasicCriterion":
-        return BasicCriterion(
-            Matching.like, self, self.wrap_constant(expr)  # type:ignore[arg-type]
-        )
+        return BasicCriterion(Matching.like, self, self.wrap_constant(expr))
 
     def not_like(self, expr: str) -> "BasicCriterion":
-        return BasicCriterion(
-            Matching.not_like, self, self.wrap_constant(expr)  # type:ignore[arg-type]
-        )
+        return BasicCriterion(Matching.not_like, self, self.wrap_constant(expr))
 
     def ilike(self, expr: str) -> "BasicCriterion":
-        return BasicCriterion(
-            Matching.ilike, self, self.wrap_constant(expr)  # type:ignore[arg-type]
-        )
+        return BasicCriterion(Matching.ilike, self, self.wrap_constant(expr))
 
     def not_ilike(self, expr: str) -> "BasicCriterion":
-        return BasicCriterion(
-            Matching.not_ilike, self, self.wrap_constant(expr)  # type:ignore[arg-type]
-        )
+        return BasicCriterion(Matching.not_ilike, self, self.wrap_constant(expr))
 
     def rlike(self, expr: str) -> "BasicCriterion":
-        return BasicCriterion(
-            Matching.rlike, self, self.wrap_constant(expr)  # type:ignore[arg-type]
-        )
+        return BasicCriterion(Matching.rlike, self, self.wrap_constant(expr))
 
     def regex(self, pattern: str) -> "BasicCriterion":
-        return BasicCriterion(
-            Matching.regex, self, self.wrap_constant(pattern)  # type:ignore[arg-type]
-        )
+        return BasicCriterion(Matching.regex, self, self.wrap_constant(pattern))
 
     def between(self, lower: Any, upper: Any) -> "BetweenCriterion":
-        return BetweenCriterion(
-            self, self.wrap_constant(lower), self.wrap_constant(upper)  # type:ignore[arg-type]
-        )
+        return BetweenCriterion(self, self.wrap_constant(lower), self.wrap_constant(upper))
 
     def from_to(self, start: Any, end: Any) -> "PeriodCriterion":
-        return PeriodCriterion(
-            self, self.wrap_constant(start), self.wrap_constant(end)  # type:ignore[arg-type]
-        )
+        return PeriodCriterion(self, self.wrap_constant(start), self.wrap_constant(end))
 
     def as_of(self, expr: str) -> "BasicCriterion":
-        return BasicCriterion(
-            Matching.as_of, self, self.wrap_constant(expr)  # type:ignore[arg-type]
-        )
+        return BasicCriterion(Matching.as_of, self, self.wrap_constant(expr))
 
     def all_(self) -> "All":
         return All(self)
@@ -218,9 +198,7 @@ class Term(Node):
         return self.isin(arg).negate()
 
     def bin_regex(self, pattern: str) -> "BasicCriterion":
-        return BasicCriterion(
-            Matching.bin_regex, self, self.wrap_constant(pattern)  # type:ignore[arg-type]
-        )
+        return BasicCriterion(Matching.bin_regex, self, self.wrap_constant(pattern))
 
     def negate(self) -> "Not":
         return Not(self)
@@ -235,24 +213,16 @@ class Term(Node):
         return Negative(self)
 
     def __add__(self, other: Any) -> "ArithmeticExpression":
-        return ArithmeticExpression(
-            Arithmetic.add, self, self.wrap_constant(other)  # type:ignore[arg-type]
-        )
+        return ArithmeticExpression(Arithmetic.add, self, self.wrap_constant(other))
 
     def __sub__(self, other: Any) -> "ArithmeticExpression":
-        return ArithmeticExpression(
-            Arithmetic.sub, self, self.wrap_constant(other)  # type:ignore[arg-type]
-        )
+        return ArithmeticExpression(Arithmetic.sub, self, self.wrap_constant(other))
 
     def __mul__(self, other: Any) -> "ArithmeticExpression":
-        return ArithmeticExpression(
-            Arithmetic.mul, self, self.wrap_constant(other)  # type:ignore[arg-type]
-        )
+        return ArithmeticExpression(Arithmetic.mul, self, self.wrap_constant(other))
 
     def __truediv__(self, other: Any) -> "ArithmeticExpression":
-        return ArithmeticExpression(
-            Arithmetic.div, self, self.wrap_constant(other)  # type:ignore[arg-type]
-        )
+        return ArithmeticExpression(Arithmetic.div, self, self.wrap_constant(other))
 
     def __pow__(self, other: Any) -> "Pow":
         return Pow(self, other)
@@ -261,46 +231,34 @@ class Term(Node):
         return Mod(self, other)
 
     def __radd__(self, other: Any) -> "ArithmeticExpression":
-        return ArithmeticExpression(
-            Arithmetic.add, self.wrap_constant(other), self  # type:ignore[arg-type]
-        )
+        return ArithmeticExpression(Arithmetic.add, self.wrap_constant(other), self)
 
     def __rsub__(self, other: Any) -> "ArithmeticExpression":
-        return ArithmeticExpression(
-            Arithmetic.sub, self.wrap_constant(other), self  # type:ignore[arg-type]
-        )
+        return ArithmeticExpression(Arithmetic.sub, self.wrap_constant(other), self)
 
     def __rmul__(self, other: Any) -> "ArithmeticExpression":
-        return ArithmeticExpression(
-            Arithmetic.mul, self.wrap_constant(other), self  # type:ignore[arg-type]
-        )
+        return ArithmeticExpression(Arithmetic.mul, self.wrap_constant(other), self)
 
     def __rtruediv__(self, other: Any) -> "ArithmeticExpression":
-        return ArithmeticExpression(
-            Arithmetic.div, self.wrap_constant(other), self  # type:ignore[arg-type]
-        )
+        return ArithmeticExpression(Arithmetic.div, self.wrap_constant(other), self)
 
     def __eq__(self, other: Any) -> "BasicCriterion":  # type:ignore[override]
-        return BasicCriterion(Equality.eq, self, self.wrap_constant(other))  # type:ignore[arg-type]
+        return BasicCriterion(Equality.eq, self, self.wrap_constant(other))
 
     def __ne__(self, other: Any) -> "BasicCriterion":  # type:ignore[override]
-        return BasicCriterion(Equality.ne, self, self.wrap_constant(other))  # type:ignore[arg-type]
+        return BasicCriterion(Equality.ne, self, self.wrap_constant(other))
 
     def __gt__(self, other: Any) -> "BasicCriterion":
-        return BasicCriterion(Equality.gt, self, self.wrap_constant(other))  # type:ignore[arg-type]
+        return BasicCriterion(Equality.gt, self, self.wrap_constant(other))
 
     def __ge__(self, other: Any) -> "BasicCriterion":
-        return BasicCriterion(
-            Equality.gte, self, self.wrap_constant(other)  # type:ignore[arg-type]
-        )
+        return BasicCriterion(Equality.gte, self, self.wrap_constant(other))
 
     def __lt__(self, other: Any) -> "BasicCriterion":
-        return BasicCriterion(Equality.lt, self, self.wrap_constant(other))  # type:ignore[arg-type]
+        return BasicCriterion(Equality.lt, self, self.wrap_constant(other))
 
     def __le__(self, other: Any) -> "BasicCriterion":
-        return BasicCriterion(
-            Equality.lte, self, self.wrap_constant(other)  # type:ignore[arg-type]
-        )
+        return BasicCriterion(Equality.lte, self, self.wrap_constant(other))
 
     def __getitem__(self, item: slice) -> "BetweenCriterion":
         if not isinstance(item, slice):
@@ -398,7 +356,7 @@ class Negative(Term):
 
     @property
     def is_aggregate(self) -> bool | None:  # type:ignore[override]
-        return self.term.is_aggregate  # type:ignore[has-type]
+        return self.term.is_aggregate
 
     def get_sql(self, ctx: SqlContext) -> str:
         return "-{term}".format(term=self.term.get_sql(ctx))
@@ -512,14 +470,14 @@ class JSON(Term):
         return BasicCriterion(
             JSONOperators.GET_JSON_VALUE,
             self,
-            self.wrap_constant(key_or_index),  # type:ignore[arg-type]
+            self.wrap_constant(key_or_index),
         )
 
     def get_text_value(self, key_or_index: str | int) -> "BasicCriterion":
         return BasicCriterion(
             JSONOperators.GET_TEXT_VALUE,
             self,
-            self.wrap_constant(key_or_index),  # type:ignore[arg-type]
+            self.wrap_constant(key_or_index),
         )
 
     def get_path_json_value(self, path_json: str) -> "BasicCriterion":
@@ -620,7 +578,7 @@ class Criterion(Term):
 
         return crit
 
-    def get_sql(self, ctx: SqlContext) -> str:  # type:ignore[override]
+    def get_sql(self, ctx: SqlContext) -> str:
         raise NotImplementedError()
 
 
@@ -672,9 +630,9 @@ class Field(Criterion, JSON):
             A copy of the field with the tables replaced.
         """
         if self.table == current_table:
-            self.table = new_table  # type:ignore[assignment]
+            self.table = new_table
 
-    def get_sql(self, ctx: SqlContext) -> str:  # type:ignore[override]
+    def get_sql(self, ctx: SqlContext) -> str:
         field_sql = format_quotes(self.name, ctx.quote_char)
 
         # Need to add namespace if the table has an alias
@@ -725,19 +683,15 @@ class Tuple(Criterion):
     def nodes_(self) -> Iterator[NodeT]:
         yield self  # type:ignore[misc]
         for value in self.values:
-            yield from value.nodes_()  # type:ignore[union-attr]
+            yield from value.nodes_()
 
     def get_sql(self, ctx: SqlContext) -> str:
-        sql = "({})".format(
-            ",".join(term.get_sql(ctx) for term in self.values)  # type:ignore[union-attr]
-        )
+        sql = "({})".format(",".join(term.get_sql(ctx) for term in self.values))
         return format_alias_sql(sql, self.alias, ctx)
 
     @property
     def is_aggregate(self) -> bool | None:  # type:ignore[override]
-        return resolve_is_aggregate(
-            [val.is_aggregate for val in self.values]  # type:ignore[has-type,union-attr]
-        )
+        return resolve_is_aggregate([val.is_aggregate for val in self.values])
 
     @builder
     def replace_table(  # type:ignore[return]
@@ -753,10 +707,7 @@ class Tuple(Criterion):
         :return:
             A copy of the field with the tables replaced.
         """
-        self.values = [
-            value.replace_table(current_table, new_table)  # type:ignore[misc,union-attr]
-            for value in self.values
-        ]
+        self.values = [value.replace_table(current_table, new_table) for value in self.values]
 
 
 class Array(Tuple):
@@ -768,7 +719,7 @@ class Array(Tuple):
         if ctx.parameterizer is None or not ctx.parameterizer.should_parameterize(
             self.original_value
         ):
-            values = ",".join(term.get_sql(ctx) for term in self.values)  # type:ignore[union-attr]
+            values = ",".join(term.get_sql(ctx) for term in self.values)
 
             sql = "[{}]".format(values)
             if ctx.dialect in (Dialects.POSTGRESQL, Dialects.REDSHIFT):
@@ -880,7 +831,7 @@ class BasicCriterion(Criterion):
 
     @property
     def is_aggregate(self) -> bool | None:  # type:ignore[override]
-        aggrs = [term.is_aggregate for term in (self.left, self.right)]  # type:ignore[has-type]
+        aggrs = [term.is_aggregate for term in (self.left, self.right)]
         return resolve_is_aggregate(aggrs)
 
     @builder
@@ -982,7 +933,7 @@ class RangeCriterion(Criterion):
 
     @property
     def is_aggregate(self) -> bool | None:  # type:ignore[override]
-        return self.term.is_aggregate  # type:ignore[has-type]
+        return self.term.is_aggregate
 
 
 class BetweenCriterion(RangeCriterion):
@@ -1090,7 +1041,7 @@ class NullCriterion(Criterion):
 
 
 class ComplexCriterion(BasicCriterion):
-    def get_sql(self, ctx: SqlContext) -> str:  # type:ignore[override]
+    def get_sql(self, ctx: SqlContext) -> str:
         left_ctx = ctx.copy(subcriterion=self.needs_brackets(self.left))
         right_ctx = ctx.copy(subcriterion=self.needs_brackets(self.right))
         sql = "{left} {comparator} {right}".format(
@@ -1249,7 +1200,7 @@ class Case(Term):
         # True if all criterions/cases are True or None. None all cases are None. Otherwise, False
         return resolve_is_aggregate(
             [criterion.is_aggregate or term.is_aggregate for criterion, term in self._cases]
-            + [self._else.is_aggregate if self._else else None]  # type:ignore[has-type]
+            + [self._else.is_aggregate if self._else else None]
         )
 
     @builder
@@ -1281,7 +1232,7 @@ class Case(Term):
 
     @builder
     def else_(self, term: Any) -> "Self":
-        self._else = self.wrap_constant(term)  # type:ignore[assignment]
+        self._else = self.wrap_constant(term)
         return self
 
     def get_sql(self, ctx: SqlContext) -> str:
@@ -1405,7 +1356,7 @@ class Function(Criterion):
     def nodes_(self) -> Iterator[NodeT]:
         yield self  # type:ignore[misc]
         for arg in self.args:
-            yield from arg.nodes_()  # type:ignore[union-attr]
+            yield from arg.nodes_()
 
     @property
     def is_aggregate(self) -> bool | None:  # type:ignore[override]
@@ -1415,9 +1366,7 @@ class Function(Criterion):
         :returns:
             True if the function accepts one argument and that argument is aggregate.
         """
-        return resolve_is_aggregate(
-            [arg.is_aggregate for arg in self.args]  # type:ignore[has-type,union-attr]
-        )
+        return resolve_is_aggregate([arg.is_aggregate for arg in self.args])
 
     @builder
     def replace_table(  # type:ignore[return]
@@ -1433,10 +1382,7 @@ class Function(Criterion):
         :return:
             A copy of the criterion with the tables replaced.
         """
-        self.args = [
-            param.replace_table(current_table, new_table)  # type:ignore[misc,union-attr]
-            for param in self.args
-        ]
+        self.args = [param.replace_table(current_table, new_table) for param in self.args]
 
     def get_special_params_sql(self, ctx: SqlContext) -> Any:
         pass

--- a/pypika_tortoise/utils.py
+++ b/pypika_tortoise/utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, Type, TypeVar
 
+from .context import SqlContext
+
 T_Retval = TypeVar("T_Retval")
 T_Self = TypeVar("T_Self")
 
@@ -78,17 +80,14 @@ def format_quotes(value: Any, quote_char: str | None) -> str:
 def format_alias_sql(
     sql: str,
     alias: str | None,
-    quote_char: str | None = None,
-    alias_quote_char: str | None = None,
-    as_keyword: bool = False,
-    **kwargs: Any,
+    ctx: SqlContext,
 ) -> str:
     if alias is None:
         return sql
     return "{sql}{_as}{alias}".format(
         sql=sql,
-        _as=" AS " if as_keyword else " ",
-        alias=format_quotes(alias, alias_quote_char or quote_char),
+        _as=" AS " if ctx.as_keyword else " ",
+        alias=format_quotes(alias, ctx.alias_quote_char or ctx.quote_char),
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypika-tortoise"
-version = "0.4.0"
+version = "0.5.0"
 description = "Forked from pypika and streamline just for tortoise-orm"
 authors = ["long2ice <long2ice@gmail.com>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
 pretty = true
 python_version = "3.8"
 ignore_missing_imports = true
+warn_unused_ignores = true
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_criterions.py
+++ b/tests/test_criterions.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 
 from pypika_tortoise import Criterion, EmptyCriterion, Field, Table
 from pypika_tortoise import functions as fn
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
 from pypika_tortoise.queries import QueryBuilder
 from pypika_tortoise.terms import Mod
 
@@ -19,7 +20,7 @@ class CriterionTests(unittest.TestCase):
         self.assertEqual('"foo"="bar"', str(c1))
         self.assertEqual(
             '"foo"="bar" "criterion"',
-            c1.get_sql(with_alias=True, quote_char='"', alias_quote_char='"'),
+            c1.get_sql(DEFAULT_SQL_CONTEXT.copy(with_alias=True)),
         )
 
     def test__criterion_eq_number(self):

--- a/tests/test_data_types.py
+++ b/tests/test_data_types.py
@@ -1,15 +1,16 @@
 import unittest
 import uuid
 
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
 from pypika_tortoise.terms import ValueWrapper
 
 
 class StringTests(unittest.TestCase):
     def test_inline_string_concatentation(self):
-        self.assertEqual("'it''s'", ValueWrapper("it's").get_sql())
+        self.assertEqual("'it''s'", ValueWrapper("it's").get_sql(DEFAULT_SQL_CONTEXT))
 
 
 class UuidTests(unittest.TestCase):
     def test_uuid_string_generation(self):
         id = uuid.uuid4()
-        self.assertEqual("'{}'".format(id), ValueWrapper(id).get_sql())
+        self.assertEqual("'{}'".format(id), ValueWrapper(id).get_sql(DEFAULT_SQL_CONTEXT))

--- a/tests/test_date_math.py
+++ b/tests/test_date_math.py
@@ -3,9 +3,9 @@ import unittest
 from pypika_tortoise import Field as F
 from pypika_tortoise import Interval
 from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
-from pypika_tortoise.dialects.mysql import MySQLQueryBuilder
-from pypika_tortoise.dialects.oracle import OracleQueryBuilder
-from pypika_tortoise.dialects.postgresql import PostgreSQLQueryBuilder
+from pypika_tortoise.dialects.mysql import MySQLQuery
+from pypika_tortoise.dialects.oracle import OracleQuery
+from pypika_tortoise.dialects.postgresql import PostgreSQLQuery
 
 dt = F("dt")
 
@@ -126,15 +126,15 @@ class AddIntervalMultipleUnitsTests(unittest.TestCase):
 
 class DialectIntervalTests(unittest.TestCase):
     def test_mysql_dialect_uses_single_quotes_around_expression_in_an_interval(self):
-        c = Interval(days=1).get_sql(MySQLQueryBuilder.SQL_CONTEXT)
+        c = Interval(days=1).get_sql(MySQLQuery.SQL_CONTEXT)
         self.assertEqual("INTERVAL '1' DAY", c)
 
     def test_oracle_dialect_uses_single_quotes_around_expression_in_an_interval(self):
-        c = Interval(days=1).get_sql(OracleQueryBuilder.SQL_CONTEXT)
+        c = Interval(days=1).get_sql(OracleQuery.SQL_CONTEXT)
         self.assertEqual("INTERVAL '1' DAY", c)
 
     def test_postgresql_dialect_uses_single_quotes_around_interval(self):
-        c = Interval(days=1).get_sql(PostgreSQLQueryBuilder.SQL_CONTEXT)
+        c = Interval(days=1).get_sql(PostgreSQLQuery.SQL_CONTEXT)
         self.assertEqual("INTERVAL '1 DAY'", c)
 
 

--- a/tests/test_date_math.py
+++ b/tests/test_date_math.py
@@ -2,7 +2,10 @@ import unittest
 
 from pypika_tortoise import Field as F
 from pypika_tortoise import Interval
-from pypika_tortoise.enums import Dialects
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
+from pypika_tortoise.dialects.mysql import MySQLQueryBuilder
+from pypika_tortoise.dialects.oracle import OracleQueryBuilder
+from pypika_tortoise.dialects.postgresql import PostgreSQLQueryBuilder
 
 dt = F("dt")
 
@@ -123,45 +126,37 @@ class AddIntervalMultipleUnitsTests(unittest.TestCase):
 
 class DialectIntervalTests(unittest.TestCase):
     def test_mysql_dialect_uses_single_quotes_around_expression_in_an_interval(self):
-        c = Interval(days=1).get_sql(dialect=Dialects.MYSQL)
+        c = Interval(days=1).get_sql(MySQLQueryBuilder.SQL_CONTEXT)
         self.assertEqual("INTERVAL '1' DAY", c)
 
     def test_oracle_dialect_uses_single_quotes_around_expression_in_an_interval(self):
-        c = Interval(days=1).get_sql(dialect=Dialects.ORACLE)
+        c = Interval(days=1).get_sql(OracleQueryBuilder.SQL_CONTEXT)
         self.assertEqual("INTERVAL '1' DAY", c)
 
-    def test_vertica_dialect_uses_single_quotes_around_interval(self):
-        c = Interval(days=1).get_sql(dialect=Dialects.VERTICA)
-        self.assertEqual("INTERVAL '1 DAY'", c)
-
-    def test_redshift_dialect_uses_single_quotes_around_interval(self):
-        c = Interval(days=1).get_sql(dialect=Dialects.REDSHIFT)
-        self.assertEqual("INTERVAL '1 DAY'", c)
-
     def test_postgresql_dialect_uses_single_quotes_around_interval(self):
-        c = Interval(days=1).get_sql(dialect=Dialects.POSTGRESQL)
+        c = Interval(days=1).get_sql(PostgreSQLQueryBuilder.SQL_CONTEXT)
         self.assertEqual("INTERVAL '1 DAY'", c)
 
 
 class TestNegativeIntervals(unittest.TestCase):
     def test_day(self):
-        c = Interval(days=-1).get_sql()
+        c = Interval(days=-1).get_sql(DEFAULT_SQL_CONTEXT)
         self.assertEqual("INTERVAL '-1 DAY'", c)
 
     def test_week(self):
-        c = Interval(weeks=-1).get_sql()
+        c = Interval(weeks=-1).get_sql(DEFAULT_SQL_CONTEXT)
         self.assertEqual("INTERVAL '-1 WEEK'", c)
 
     def test_month(self):
-        c = Interval(months=-1).get_sql()
+        c = Interval(months=-1).get_sql(DEFAULT_SQL_CONTEXT)
         self.assertEqual("INTERVAL '-1 MONTH'", c)
 
     def test_year(self):
-        c = Interval(years=-1).get_sql()
+        c = Interval(years=-1).get_sql(DEFAULT_SQL_CONTEXT)
         self.assertEqual("INTERVAL '-1 YEAR'", c)
 
     def test_year_month(self):
-        c = Interval(years=-1, months=-4).get_sql()
+        c = Interval(years=-1, months=-4).get_sql(DEFAULT_SQL_CONTEXT)
         self.assertEqual("INTERVAL '-1-4 YEAR_MONTH'", c)
 
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -2,6 +2,7 @@ import unittest
 
 from pypika_tortoise import Query, Tables
 from pypika_tortoise import functions as fn
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
 
 
 class QuoteTests(unittest.TestCase):
@@ -47,7 +48,7 @@ class QuoteTests(unittest.TestCase):
             "`foo` `foo_two`,`bar` "
             "FROM `efg`"
             ") `sq1` ON `sq0`.`foo`=`sq1`.`foo_two`",
-            self.query.get_sql(quote_char="`"),
+            self.query.get_sql(DEFAULT_SQL_CONTEXT.copy(quote_char="`")),
         )
 
     def test_no_quote_char_in_complex_query(self):
@@ -65,5 +66,5 @@ class QuoteTests(unittest.TestCase):
             "foo foo_two,bar "
             "FROM efg"
             ") sq1 ON sq0.foo=sq1.foo_two",
-            self.query.get_sql(quote_char=None),
+            self.query.get_sql(DEFAULT_SQL_CONTEXT.copy(quote_char=None)),
         )

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -7,13 +7,17 @@ from pypika_tortoise import Query as Q
 from pypika_tortoise import Schema
 from pypika_tortoise import Table as T
 from pypika_tortoise import functions as fn
-from pypika_tortoise.enums import Dialects, SqlTypes
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
+from pypika_tortoise.dialects.postgresql import PostgreSQLQueryBuilder
+from pypika_tortoise.enums import SqlTypes
 
 
 class FunctionTests(unittest.TestCase):
     def test_dialect_propagation(self):
         func = fn.Function("func", ["a"], ["b"])
-        self.assertEqual("func(ARRAY['a'],ARRAY['b'])", func.get_sql(dialect=Dialects.POSTGRESQL))
+        self.assertEqual(
+            "func(ARRAY['a'],ARRAY['b'])", func.get_sql(PostgreSQLQueryBuilder.SQL_CONTEXT)
+        )
 
     def test_is_aggregate_None_for_non_aggregate_function_or_function_with_no_aggregate_functions(
         self,
@@ -31,13 +35,15 @@ class SchemaTests(unittest.TestCase):
     def test_schema_no_schema_in_sql_when_none_set(self):
         func = fn.Function("my_proc", 1, 2, 3)
 
-        self.assertEqual("my_proc(1,2,3)", func.get_sql(quote_char='"'))
+        self.assertEqual("my_proc(1,2,3)", func.get_sql(DEFAULT_SQL_CONTEXT.copy(quote_char='"')))
 
     def test_schema_included_in_function_sql(self):
         a = Schema("a")
         func = fn.Function("my_proc", 1, 2, 3, schema=a)
 
-        self.assertEqual('"a".my_proc(1,2,3)', func.get_sql(quote_char='"'))
+        self.assertEqual(
+            '"a".my_proc(1,2,3)', func.get_sql(DEFAULT_SQL_CONTEXT.copy(quote_char='"'))
+        )
 
 
 class ArithmeticTests(unittest.TestCase):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -8,16 +8,14 @@ from pypika_tortoise import Schema
 from pypika_tortoise import Table as T
 from pypika_tortoise import functions as fn
 from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
-from pypika_tortoise.dialects.postgresql import PostgreSQLQueryBuilder
+from pypika_tortoise.dialects.postgresql import PostgreSQLQuery
 from pypika_tortoise.enums import SqlTypes
 
 
 class FunctionTests(unittest.TestCase):
     def test_dialect_propagation(self):
         func = fn.Function("func", ["a"], ["b"])
-        self.assertEqual(
-            "func(ARRAY['a'],ARRAY['b'])", func.get_sql(PostgreSQLQueryBuilder.SQL_CONTEXT)
-        )
+        self.assertEqual("func(ARRAY['a'],ARRAY['b'])", func.get_sql(PostgreSQLQuery.SQL_CONTEXT))
 
     def test_is_aggregate_None_for_non_aggregate_function_or_function_with_no_aggregate_functions(
         self,

--- a/tests/test_joins.py
+++ b/tests/test_joins.py
@@ -13,6 +13,7 @@ from pypika_tortoise import (
     Tables,
 )
 from pypika_tortoise import functions as fn
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -270,7 +271,10 @@ class SelectQueryJoinTests(unittest.TestCase):
     def test_join_using_with_quote_char(self):
         query = Query.from_(self.table0).join(self.table1).using("foo", "bar").select("*")
 
-        self.assertEqual("SELECT * FROM abc JOIN efg USING (foo,bar)", query.get_sql(quote_char=""))
+        self.assertEqual(
+            "SELECT * FROM abc JOIN efg USING (foo,bar)",
+            query.get_sql(DEFAULT_SQL_CONTEXT.copy(quote_char="")),
+        )
 
     def test_join_using_without_fields_raises_exception(self):
         with self.assertRaises(JoinException):
@@ -972,16 +976,6 @@ class UnionTests(unittest.TestCase):
             str(q),
         )
 
-    def test_union_with_no_quote_char(self):
-        abc, efg = Tables("abc", "efg")
-        hij = Query.from_(abc).select(abc.t).union(Query.from_(efg).select(efg.t))
-        q = Query.from_(hij).select(fn.Avg(hij.t))
-
-        self.assertEqual(
-            "SELECT AVG(sq0.t) FROM ((SELECT t FROM abc) UNION (SELECT t FROM efg)) sq0",
-            q.get_sql(quote_char=None),
-        )
-
 
 class InsertQueryJoinTests(unittest.TestCase):
     def test_join_table_on_insert_query(self):
@@ -1121,16 +1115,6 @@ class IntersectTests(unittest.TestCase):
             str(q),
         )
 
-    def test_intersect_with_no_quote_char(self):
-        abc, efg = Tables("abc", "efg")
-        hij = Query.from_(abc).select(abc.t).intersect(Query.from_(efg).select(efg.t))
-        q = Query.from_(hij).select(fn.Avg(hij.t))
-
-        self.assertEqual(
-            "SELECT AVG(sq0.t) FROM ((SELECT t FROM abc) INTERSECT (SELECT t FROM efg)) sq0",
-            q.get_sql(quote_char=None),
-        )
-
 
 class MinusTests(unittest.TestCase):
     table1, table2 = Tables("abc", "efg")
@@ -1226,16 +1210,6 @@ class MinusTests(unittest.TestCase):
             str(q),
         )
 
-    def test_minus_with_no_quote_char(self):
-        abc, efg = Tables("abc", "efg")
-        hij = Query.from_(abc).select(abc.t).minus(Query.from_(efg).select(efg.t))
-        q = Query.from_(hij).select(fn.Avg(hij.t))
-
-        self.assertEqual(
-            "SELECT AVG(sq0.t) FROM ((SELECT t FROM abc) MINUS (SELECT t FROM efg)) sq0",
-            q.get_sql(quote_char=None),
-        )
-
 
 class ExceptOfTests(unittest.TestCase):
     table1, table2 = Tables("abc", "efg")
@@ -1308,14 +1282,4 @@ class ExceptOfTests(unittest.TestCase):
         self.assertEqual(
             'SELECT AVG("sq0"."t") FROM ((SELECT "t" FROM "abc") EXCEPT (SELECT "t" FROM "efg")) "sq0"',
             str(q),
-        )
-
-    def test_except_with_no_quote_char(self):
-        abc, efg = Tables("abc", "efg")
-        hij = Query.from_(abc).select(abc.t).except_of(Query.from_(efg).select(efg.t))
-        q = Query.from_(hij).select(fn.Avg(hij.t))
-
-        self.assertEqual(
-            "SELECT AVG(sq0.t) FROM ((SELECT t FROM abc) EXCEPT (SELECT t FROM efg)) sq0",
-            q.get_sql(quote_char=None),
         )

--- a/tests/test_negation.py
+++ b/tests/test_negation.py
@@ -2,6 +2,7 @@ import unittest
 
 from pypika_tortoise import Tables
 from pypika_tortoise import functions as fn
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
 from pypika_tortoise.terms import ValueWrapper
 
 
@@ -11,19 +12,24 @@ class NegationTests(unittest.TestCase):
     def test_negate_wrapped_float(self):
         q = -ValueWrapper(1.0)
 
-        self.assertEqual("-1.0", q.get_sql())
+        self.assertEqual("-1.0", q.get_sql(DEFAULT_SQL_CONTEXT))
 
     def test_negate_wrapped_int(self):
         q = -ValueWrapper(1)
 
-        self.assertEqual("-1", q.get_sql())
+        self.assertEqual("-1", q.get_sql(DEFAULT_SQL_CONTEXT))
 
     def test_negate_field(self):
         q = -self.table_abc.foo
 
-        self.assertEqual('-"abc"."foo"', q.get_sql(with_namespace=True, quote_char='"'))
+        self.assertEqual(
+            '-"abc"."foo"', q.get_sql(DEFAULT_SQL_CONTEXT.copy(with_namespace=True, quote_char='"'))
+        )
 
     def test_negate_function(self):
         q = -fn.Sum(self.table_abc.foo)
 
-        self.assertEqual('-SUM("abc"."foo")', q.get_sql(with_namespace=True, quote_char='"'))
+        self.assertEqual(
+            '-SUM("abc"."foo")',
+            q.get_sql(DEFAULT_SQL_CONTEXT.copy(with_namespace=True, quote_char='"')),
+        )

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -3,11 +3,11 @@ from datetime import date
 
 from pypika_tortoise import Parameter, Query, Tables, ValueWrapper
 from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
-from pypika_tortoise.dialects.mssql import MSSQLQuery, MSSQLQueryBuilder
-from pypika_tortoise.dialects.mysql import MySQLQuery, MySQLQueryBuilder
-from pypika_tortoise.dialects.oracle import OracleQueryBuilder
-from pypika_tortoise.dialects.postgresql import PostgreSQLQuery, PostgreSQLQueryBuilder
-from pypika_tortoise.dialects.sqlite import SQLLiteQueryBuilder
+from pypika_tortoise.dialects.mssql import MSSQLQuery
+from pypika_tortoise.dialects.mysql import MySQLQuery
+from pypika_tortoise.dialects.oracle import OracleQuery
+from pypika_tortoise.dialects.postgresql import PostgreSQLQuery
+from pypika_tortoise.dialects.sqlite import SQLLiteQuery
 from pypika_tortoise.functions import Upper
 from pypika_tortoise.terms import Case, Parameterizer
 
@@ -87,24 +87,24 @@ class ParametrizedTests(unittest.TestCase):
         self.assertEqual("?", Parameter("?").get_sql(DEFAULT_SQL_CONTEXT))
 
     def test_oracle(self):
-        self.assertEqual("?", Parameter(idx=1).get_sql(OracleQueryBuilder.SQL_CONTEXT))
-        self.assertEqual("?", Parameter(idx=2).get_sql(OracleQueryBuilder.SQL_CONTEXT))
+        self.assertEqual("?", Parameter(idx=1).get_sql(OracleQuery.SQL_CONTEXT))
+        self.assertEqual("?", Parameter(idx=2).get_sql(OracleQuery.SQL_CONTEXT))
 
     def test_mssql(self):
-        self.assertEqual("?", Parameter(idx=1).get_sql(MSSQLQueryBuilder.SQL_CONTEXT))
-        self.assertEqual("?", Parameter(idx=2).get_sql(MSSQLQueryBuilder.SQL_CONTEXT))
+        self.assertEqual("?", Parameter(idx=1).get_sql(MSSQLQuery.SQL_CONTEXT))
+        self.assertEqual("?", Parameter(idx=2).get_sql(MSSQLQuery.SQL_CONTEXT))
 
     def test_mysql(self):
-        self.assertEqual("%s", Parameter(idx=1).get_sql(MySQLQueryBuilder.SQL_CONTEXT))
-        self.assertEqual("%s", Parameter(idx=2).get_sql(MySQLQueryBuilder.SQL_CONTEXT))
+        self.assertEqual("%s", Parameter(idx=1).get_sql(MySQLQuery.SQL_CONTEXT))
+        self.assertEqual("%s", Parameter(idx=2).get_sql(MySQLQuery.SQL_CONTEXT))
 
     def test_postgres(self):
-        self.assertEqual("$1", Parameter(idx=1).get_sql(PostgreSQLQueryBuilder.SQL_CONTEXT))
-        self.assertEqual("$2", Parameter(idx=2).get_sql(PostgreSQLQueryBuilder.SQL_CONTEXT))
+        self.assertEqual("$1", Parameter(idx=1).get_sql(PostgreSQLQuery.SQL_CONTEXT))
+        self.assertEqual("$2", Parameter(idx=2).get_sql(PostgreSQLQuery.SQL_CONTEXT))
 
     def test_sqlite(self):
-        self.assertEqual("?", Parameter(idx=1).get_sql(SQLLiteQueryBuilder.SQL_CONTEXT))
-        self.assertEqual("?", Parameter(idx=2).get_sql(SQLLiteQueryBuilder.SQL_CONTEXT))
+        self.assertEqual("?", Parameter(idx=1).get_sql(SQLLiteQuery.SQL_CONTEXT))
+        self.assertEqual("?", Parameter(idx=2).get_sql(SQLLiteQuery.SQL_CONTEXT))
 
 
 class ParameterizerTests(unittest.TestCase):
@@ -232,4 +232,4 @@ class ParameterizerTests(unittest.TestCase):
     def test_placeholder_factory(self):
         parameterizer = Parameterizer(placeholder_factory=lambda _: "%s")
         param = parameterizer.create_param(1)
-        self.assertEqual("%s", param.get_sql(PostgreSQLQueryBuilder.SQL_CONTEXT))
+        self.assertEqual("%s", param.get_sql(PostgreSQLQuery.SQL_CONTEXT))

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -2,10 +2,12 @@ import unittest
 from datetime import date
 
 from pypika_tortoise import Parameter, Query, Tables, ValueWrapper
-from pypika_tortoise.dialects.mssql import MSSQLQuery
-from pypika_tortoise.dialects.mysql import MySQLQuery
-from pypika_tortoise.dialects.postgresql import PostgreSQLQuery
-from pypika_tortoise.enums import Dialects
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
+from pypika_tortoise.dialects.mssql import MSSQLQuery, MSSQLQueryBuilder
+from pypika_tortoise.dialects.mysql import MySQLQuery, MySQLQueryBuilder
+from pypika_tortoise.dialects.oracle import OracleQueryBuilder
+from pypika_tortoise.dialects.postgresql import PostgreSQLQuery, PostgreSQLQueryBuilder
+from pypika_tortoise.dialects.sqlite import SQLLiteQueryBuilder
 from pypika_tortoise.functions import Upper
 from pypika_tortoise.terms import Case, Parameterizer
 
@@ -82,27 +84,27 @@ class ParametrizedTests(unittest.TestCase):
         )
 
     def test_qmark_parameter(self):
-        self.assertEqual("?", Parameter("?").get_sql())
+        self.assertEqual("?", Parameter("?").get_sql(DEFAULT_SQL_CONTEXT))
 
     def test_oracle(self):
-        self.assertEqual("?", Parameter(idx=1).get_sql(dialect=Dialects.ORACLE))
-        self.assertEqual("?", Parameter(idx=2).get_sql(dialect=Dialects.ORACLE))
+        self.assertEqual("?", Parameter(idx=1).get_sql(OracleQueryBuilder.SQL_CONTEXT))
+        self.assertEqual("?", Parameter(idx=2).get_sql(OracleQueryBuilder.SQL_CONTEXT))
 
     def test_mssql(self):
-        self.assertEqual("?", Parameter(idx=1).get_sql(dialect=Dialects.MSSQL))
-        self.assertEqual("?", Parameter(idx=2).get_sql(dialect=Dialects.MSSQL))
+        self.assertEqual("?", Parameter(idx=1).get_sql(MSSQLQueryBuilder.SQL_CONTEXT))
+        self.assertEqual("?", Parameter(idx=2).get_sql(MSSQLQueryBuilder.SQL_CONTEXT))
 
     def test_mysql(self):
-        self.assertEqual("%s", Parameter(idx=1).get_sql(dialect=Dialects.MYSQL))
-        self.assertEqual("%s", Parameter(idx=2).get_sql(dialect=Dialects.MYSQL))
+        self.assertEqual("%s", Parameter(idx=1).get_sql(MySQLQueryBuilder.SQL_CONTEXT))
+        self.assertEqual("%s", Parameter(idx=2).get_sql(MySQLQueryBuilder.SQL_CONTEXT))
 
     def test_postgres(self):
-        self.assertEqual("$1", Parameter(idx=1).get_sql(dialect=Dialects.POSTGRESQL))
-        self.assertEqual("$2", Parameter(idx=2).get_sql(dialect=Dialects.POSTGRESQL))
+        self.assertEqual("$1", Parameter(idx=1).get_sql(PostgreSQLQueryBuilder.SQL_CONTEXT))
+        self.assertEqual("$2", Parameter(idx=2).get_sql(PostgreSQLQueryBuilder.SQL_CONTEXT))
 
     def test_sqlite(self):
-        self.assertEqual("?", Parameter(idx=1).get_sql(dialect=Dialects.SQLITE))
-        self.assertEqual("?", Parameter(idx=2).get_sql(dialect=Dialects.SQLITE))
+        self.assertEqual("?", Parameter(idx=1).get_sql(SQLLiteQueryBuilder.SQL_CONTEXT))
+        self.assertEqual("?", Parameter(idx=2).get_sql(SQLLiteQueryBuilder.SQL_CONTEXT))
 
 
 class ParameterizerTests(unittest.TestCase):
@@ -111,10 +113,9 @@ class ParameterizerTests(unittest.TestCase):
     def test_param_insert(self):
         q = Query.into(self.table_abc).columns("a", "b", "c").insert(1, 2.2, "foo")
 
-        parameterizer = Parameterizer()
-        sql = q.get_sql(parameterizer=parameterizer)
+        sql, values = q.get_parameterized_sql()
         self.assertEqual('INSERT INTO "abc" ("a","b","c") VALUES (?,?,?)', sql)
-        self.assertEqual([1, 2.2, "foo"], parameterizer.values)
+        self.assertEqual([1, 2.2, "foo"], values)
 
     def test_select_join_in_mysql(self):
         q = (
@@ -127,13 +128,12 @@ class ParameterizerTests(unittest.TestCase):
             .limit(10)
         )
 
-        parameterizer = Parameterizer()
-        sql = q.get_sql(parameterizer=parameterizer, dialect=Dialects.MYSQL)
+        sql, values = q.get_parameterized_sql()
         self.assertEqual(
             "SELECT * FROM `abc` JOIN `efg` ON `abc`.`id`=`efg`.`abc_id` WHERE `abc`.`category`=%s AND `efg`.`date`>=%s LIMIT %s",
             sql,
         )
-        self.assertEqual(["foobar", date(2024, 2, 22), 10], parameterizer.values)
+        self.assertEqual(["foobar", date(2024, 2, 22), 10], values)
 
     def test_select_subquery_in_postgres(self):
         q = (
@@ -150,13 +150,12 @@ class ParameterizerTests(unittest.TestCase):
             .limit(10)
         )
 
-        parameterizer = Parameterizer()
-        sql = q.get_sql(parameterizer=parameterizer, dialect=Dialects.POSTGRESQL)
+        sql, values = q.get_parameterized_sql()
         self.assertEqual(
             'SELECT * FROM "abc" WHERE "category"=$1 AND "id" IN (SELECT "abc_id" FROM "efg" WHERE "date">=$2) LIMIT $3',
             sql,
         )
-        self.assertEqual(["foobar", date(2024, 2, 22), 10], parameterizer.values)
+        self.assertEqual(["foobar", date(2024, 2, 22), 10], values)
 
     def test_join_in_postgres(self):
         subquery = (
@@ -173,14 +172,13 @@ class ParameterizerTests(unittest.TestCase):
             .where(self.table_abc.bar == "bar")
         )
 
-        parameterizer = Parameterizer()
-        sql = q.get_sql(parameterizer=parameterizer, dialect=Dialects.POSTGRESQL)
+        sql, values = q.get_parameterized_sql()
         self.assertEqual(
             'SELECT "abc"."foo","sq0"."fiz" FROM "abc" JOIN (SELECT "fiz","buz" FROM "efg" WHERE "buz"=$1)'
             ' "sq0" ON "abc"."bar"="sq0"."buz" WHERE "abc"."bar"=$2',
             sql,
         )
-        self.assertEqual(["buz", "bar"], parameterizer.values)
+        self.assertEqual(["buz", "bar"], values)
 
     def test_function_parameter(self):
         q = (
@@ -188,20 +186,18 @@ class ParameterizerTests(unittest.TestCase):
             .select("*")
             .where(self.table_abc.category == Upper(ValueWrapper("foobar")))
         )
-        parameterizer = Parameterizer()
-        sql = q.get_sql(parameterizer=parameterizer)
+        sql, values = q.get_parameterized_sql()
         self.assertEqual('SELECT * FROM "abc" WHERE "category"=UPPER(?)', sql)
 
-        self.assertEqual(["foobar"], parameterizer.values)
+        self.assertEqual(["foobar"], values)
 
     def test_case_when_in_select(self):
         q = Query.from_(self.table_abc).select(
             Case().when(self.table_abc.category == "foobar", 1).else_(2)
         )
-        parameterizer = Parameterizer()
-        sql = q.get_sql(parameterizer=parameterizer)
+        sql, values = q.get_parameterized_sql()
         self.assertEqual('SELECT CASE WHEN "category"=? THEN ? ELSE ? END FROM "abc"', sql)
-        self.assertEqual(["foobar", 1, 2], parameterizer.values)
+        self.assertEqual(["foobar", 1, 2], values)
 
     def test_case_when_in_where(self):
         q = (
@@ -212,31 +208,28 @@ class ParameterizerTests(unittest.TestCase):
                 > Case().when(self.table_abc.category == "foobar", 1).else_(2)
             )
         )
-        parameterizer = Parameterizer()
-        sql = q.get_sql(parameterizer=parameterizer)
+        sql, values = q.get_parameterized_sql()
         self.assertEqual(
             'SELECT * FROM "abc" WHERE "category_int">CASE WHEN "category"=? THEN ? ELSE ? END',
             sql,
         )
-        self.assertEqual(["foobar", 1, 2], parameterizer.values)
+        self.assertEqual(["foobar", 1, 2], values)
 
     def test_limit_and_offest(self):
         q = Query.from_(self.table_abc).select("*").limit(10).offset(5)
-        parameterizer = Parameterizer()
-        sql = q.get_sql(parameterizer=parameterizer)
+        sql, values = q.get_parameterized_sql()
         self.assertEqual('SELECT * FROM "abc" LIMIT ? OFFSET ?', sql)
-        self.assertEqual([10, 5], parameterizer.values)
+        self.assertEqual([10, 5], values)
 
     def test_limit_and_offest_in_mssql(self):
         q = MSSQLQuery.from_(self.table_abc).select("*").limit(10).offset(5)
-        parameterizer = Parameterizer()
-        sql = q.get_sql(parameterizer=parameterizer)
+        sql, values = q.get_parameterized_sql()
         self.assertEqual(
             'SELECT * FROM "abc" ORDER BY (SELECT 0) OFFSET ? ROWS FETCH NEXT ? ROWS ONLY', sql
         )
-        self.assertEqual([5, 10], parameterizer.values)
+        self.assertEqual([5, 10], values)
 
     def test_placeholder_factory(self):
         parameterizer = Parameterizer(placeholder_factory=lambda _: "%s")
         param = parameterizer.create_param(1)
-        self.assertEqual("%s", param.get_sql())
+        self.assertEqual("%s", param.get_sql(PostgreSQLQueryBuilder.SQL_CONTEXT))

--- a/tests/test_selects.py
+++ b/tests/test_selects.py
@@ -655,7 +655,7 @@ class GroupByTests(unittest.TestCase):
         ]:
             q = query_cls.from_(self.t).select(fn.Sum(self.t.foo), bar).groupby(bar)
 
-            quote_char = query_cls._builder().SQL_CONTEXT.quote_char
+            quote_char = query_cls.SQL_CONTEXT.quote_char
 
             self.assertEqual(
                 "SELECT "

--- a/tests/test_selects.py
+++ b/tests/test_selects.py
@@ -17,6 +17,7 @@ from pypika_tortoise import (
     Tables,
 )
 from pypika_tortoise import functions as fn
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
 from pypika_tortoise.terms import Field, ValueWrapper
 
 __author__ = "Timothy Heys"
@@ -641,7 +642,7 @@ class GroupByTests(unittest.TestCase):
 
         self.assertEqual(
             'SELECT SUM("foo"),"bar" "bar01" FROM "abc" GROUP BY "bar"',
-            q.get_sql(groupby_alias=False),
+            q.get_sql(DEFAULT_SQL_CONTEXT.copy(groupby_alias=False)),
         )
 
     def test_groupby__alias_platforms(self):
@@ -654,11 +655,7 @@ class GroupByTests(unittest.TestCase):
         ]:
             q = query_cls.from_(self.t).select(fn.Sum(self.t.foo), bar).groupby(bar)
 
-            quote_char = (
-                query_cls._builder().QUOTE_CHAR
-                if isinstance(query_cls._builder().QUOTE_CHAR, str)
-                else '"'
-            )
+            quote_char = query_cls._builder().SQL_CONTEXT.quote_char
 
             self.assertEqual(
                 "SELECT "
@@ -844,7 +841,7 @@ class OrderByTests(unittest.TestCase):
 
         self.assertEqual(
             'SELECT SUM("foo"),"bar" "bar01" FROM "abc" ORDER BY "bar"',
-            q.get_sql(orderby_alias=False),
+            q.get_sql(DEFAULT_SQL_CONTEXT.copy(orderby_alias=False)),
         )
 
     def test_orderby_alias(self):
@@ -1240,5 +1237,5 @@ class QuoteTests(unittest.TestCase):
             "SELECT t1.value FROM table1 t1 "
             "JOIN table2 t2 ON t1.Value "
             "BETWEEN t2.start AND t2.end",
-            query.get_sql(quote_char=None),
+            query.get_sql(DEFAULT_SQL_CONTEXT.copy(quote_char="")),
         )

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -172,36 +172,36 @@ class TableDialectTests(unittest.TestCase):
     def test_table_with_default_query_cls(self):
         table = Table("abc")
         q = table.select("1")
-        self.assertIs(q.SQL_CONTEXT.dialect, Dialects.SQLITE)
+        self.assertIs(q.QUERY_CLS.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_table_with_dialect_query_cls(self):
         table = Table("abc", query_cls=SQLLiteQuery)
         q = table.select("1")
-        self.assertIs(q.SQL_CONTEXT.dialect, Dialects.SQLITE)
+        self.assertIs(q.QUERY_CLS.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_table_factory_with_default_query_cls(self):
         table = Query.Table("abc")
         q = table.select("1")
-        self.assertIs(q.SQL_CONTEXT.dialect, Dialects.SQLITE)
+        self.assertIs(q.QUERY_CLS.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_table_factory_with_dialect_query_cls(self):
         table = SQLLiteQuery.Table("abc")
         q = table.select("1")
-        self.assertIs(q.SQL_CONTEXT.dialect, Dialects.SQLITE)
+        self.assertIs(q.QUERY_CLS.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_make_tables_factory_with_default_query_cls(self):
         t1, t2 = Query.Tables("abc", "def")
         q1 = t1.select("1")
         q2 = t2.select("2")
-        self.assertIs(q1.SQL_CONTEXT.dialect, Dialects.SQLITE)
-        self.assertIs(q2.SQL_CONTEXT.dialect, Dialects.SQLITE)
+        self.assertIs(q1.QUERY_CLS.SQL_CONTEXT.dialect, Dialects.SQLITE)
+        self.assertIs(q2.QUERY_CLS.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_make_tables_factory_with_dialect_query_cls(self):
         t1, t2 = SQLLiteQuery.Tables("abc", "def")
         q1 = t1.select("1")
         q2 = t2.select("2")
-        self.assertIs(q1.SQL_CONTEXT.dialect, Dialects.SQLITE)
-        self.assertIs(q2.SQL_CONTEXT.dialect, Dialects.SQLITE)
+        self.assertIs(q1.QUERY_CLS.SQL_CONTEXT.dialect, Dialects.SQLITE)
+        self.assertIs(q2.QUERY_CLS.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_table_with_bad_query_cls(self):
         with self.assertRaises(TypeError):

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -11,6 +11,7 @@ from pypika_tortoise import (
     Table,
     Tables,
 )
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
 
 __author__ = "Timothy Heys"
 __email__ = "theys@kayak.com"
@@ -25,7 +26,10 @@ class TableStructureTests(unittest.TestCase):
     def test_table_with_alias(self):
         table = Table("test_table").as_("my_table")
 
-        self.assertEqual('"test_table" "my_table"', table.get_sql(with_alias=True, quote_char='"'))
+        self.assertEqual(
+            '"test_table" "my_table"',
+            table.get_sql(DEFAULT_SQL_CONTEXT.copy(with_alias=True, quote_char='"')),
+        )
 
     def test_schema_table_attr(self):
         table = Schema("x_schema").test_table
@@ -168,36 +172,36 @@ class TableDialectTests(unittest.TestCase):
     def test_table_with_default_query_cls(self):
         table = Table("abc")
         q = table.select("1")
-        self.assertIs(q.dialect, None)
+        self.assertIs(q.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_table_with_dialect_query_cls(self):
         table = Table("abc", query_cls=SQLLiteQuery)
         q = table.select("1")
-        self.assertIs(q.dialect, Dialects.SQLITE)
+        self.assertIs(q.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_table_factory_with_default_query_cls(self):
         table = Query.Table("abc")
         q = table.select("1")
-        self.assertIs(q.dialect, None)
+        self.assertIs(q.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_table_factory_with_dialect_query_cls(self):
         table = SQLLiteQuery.Table("abc")
         q = table.select("1")
-        self.assertIs(q.dialect, Dialects.SQLITE)
+        self.assertIs(q.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_make_tables_factory_with_default_query_cls(self):
         t1, t2 = Query.Tables("abc", "def")
         q1 = t1.select("1")
         q2 = t2.select("2")
-        self.assertIs(q1.dialect, None)
-        self.assertIs(q2.dialect, None)
+        self.assertIs(q1.SQL_CONTEXT.dialect, Dialects.SQLITE)
+        self.assertIs(q2.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_make_tables_factory_with_dialect_query_cls(self):
         t1, t2 = SQLLiteQuery.Tables("abc", "def")
         q1 = t1.select("1")
         q2 = t2.select("2")
-        self.assertIs(q1.dialect, Dialects.SQLITE)
-        self.assertIs(q2.dialect, Dialects.SQLITE)
+        self.assertIs(q1.SQL_CONTEXT.dialect, Dialects.SQLITE)
+        self.assertIs(q2.SQL_CONTEXT.dialect, Dialects.SQLITE)
 
     def test_table_with_bad_query_cls(self):
         with self.assertRaises(TypeError):

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from pypika_tortoise import Field, Query, Table
+from pypika_tortoise.context import DEFAULT_SQL_CONTEXT
 from pypika_tortoise.terms import AtTimezone, Parameterizer, ValueWrapper
 
 
@@ -47,17 +48,21 @@ class AtTimezoneTests(TestCase):
         self.assertEqual(
             'SELECT "customers"."date" AT TIME ZONE \'US/Eastern\' "alias1" '
             'FROM "customers" JOIN "accounts" ON "customers"."account_id"="accounts"."account_id"',
-            query.get_sql(with_namespace=True),
+            query.get_sql(DEFAULT_SQL_CONTEXT.copy(with_namespace=True)),
         )
 
 
 class ValueWrapperTests(TestCase):
     def test_allow_parametrize(self):
         value = ValueWrapper("foo")
-        self.assertEqual("'foo'", value.get_sql())
+        self.assertEqual("'foo'", value.get_sql(DEFAULT_SQL_CONTEXT))
 
         value = ValueWrapper("foo")
-        self.assertEqual("?", value.get_sql(parameterizer=Parameterizer()))
+        self.assertEqual(
+            "?", value.get_sql(DEFAULT_SQL_CONTEXT.copy(parameterizer=Parameterizer()))
+        )
 
         value = ValueWrapper("foo", allow_parametrize=False)
-        self.assertEqual("'foo'", value.get_sql(parameterizer=Parameterizer()))
+        self.assertEqual(
+            "'foo'", value.get_sql(DEFAULT_SQL_CONTEXT.copy(parameterizer=Parameterizer()))
+        )

--- a/tests/test_tuples.py
+++ b/tests/test_tuples.py
@@ -2,7 +2,7 @@ import unittest
 
 from pypika_tortoise import Array, Bracket, PostgreSQLQuery, Query, Table, Tables, Tuple
 from pypika_tortoise.functions import Coalesce, NullIf, Sum
-from pypika_tortoise.terms import Field, Parameterizer, Star
+from pypika_tortoise.terms import Field, Star
 
 
 class TupleTests(unittest.TestCase):
@@ -152,8 +152,7 @@ class ArrayTests(unittest.TestCase):
     def test_parametrization(self):
         q = Query.from_(self.table_abc).select(Star()).where(self.table_abc.f == Array(1, 2, 3))
 
-        parameterizer = Parameterizer()
-        sql = q.get_sql(parameterizer=parameterizer)
+        sql, _ = q.get_parameterized_sql()
         self.assertEqual('SELECT * FROM "abc" WHERE "f"=?', sql)
 
 


### PR DESCRIPTION
This PR replaces `kwargs` of `get_sql` with the `SqlContext` dataclass. This improves performance of SQL generation because the removal of `kwargs` eliminates the need to create a `dict` on each `get_sql` invocation. Also the dataclass explicitly documents all possible parameters as opposed to `kwargs` that made it quite hard to track.

For performance metrics, see [the tortoise-orm PR](https://github.com/tortoise/tortoise-orm/pull/1837), which is dependent on this PR.

This PR also adds the `warn_unused_ignores = true` mypy option and removes unnecessary type ignores.

This PR bumps version to 0.5.0.