### PR TITLE
Add SELECT ... FOR NO KEY UPDATE support for PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Drop support for Python3.8 (#25)
 - fix: failed to run `poetry add pypika-tortoise` with poetry v2 (#26)
+- Add `no_key` parameter to `QueryBuilder.for_update` for PostgreSQL
 
 ## 0.5
 

--- a/pypika_tortoise/dialects/postgresql.py
+++ b/pypika_tortoise/dialects/postgresql.py
@@ -197,3 +197,8 @@ class PostgreSQLQueryBuilder(QueryBuilder):
             returning_ctx = ctx.copy(with_namespace=self._update_table and self.from_)
             querystring += self._returning_sql(returning_ctx)
         return querystring
+
+    def _for_update_sql(self, ctx: SqlContext, lock_strength="UPDATE") -> str:
+        if self._for_update and self._for_update_no_key:
+            lock_strength = "NO KEY UPDATE"
+        return super()._for_update_sql(ctx, lock_strength=lock_strength)

--- a/pypika_tortoise/queries.py
+++ b/pypika_tortoise/queries.py
@@ -710,6 +710,7 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
         self._for_update_nowait = False
         self._for_update_skip_locked = False
         self._for_update_of: set[str] = set()
+        self._for_update_no_key = False
 
         self._wheres: QueryBuilder | Term | None = None
         self._prewheres: Criterion | None = None
@@ -1054,11 +1055,13 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
         nowait: bool = False,
         skip_locked: bool = False,
         of: tuple[str, ...] = (),
+        no_key: bool = False,
     ) -> "Self":
         self._for_update = True
         self._for_update_skip_locked = skip_locked
         self._for_update_nowait = nowait
         self._for_update_of = set(of)
+        self._for_update_no_key = no_key
 
     @builder
     def do_nothing(self) -> "Self":  # type:ignore[return]
@@ -1561,9 +1564,9 @@ class QueryBuilder(Selectable, Term):  # type:ignore[misc]
     def _distinct_sql(self, ctx: SqlContext) -> str:
         return "DISTINCT " if self._distinct else ""
 
-    def _for_update_sql(self, ctx: SqlContext) -> str:
+    def _for_update_sql(self, ctx: SqlContext, lock_strength="UPDATE") -> str:
         if self._for_update:
-            for_update = " FOR UPDATE"
+            for_update = f" FOR {lock_strength}"
             if self._for_update_of:
                 for_update += (
                     f' OF {", ".join([Table(item).get_sql(ctx) for item in self._for_update_of])}'

--- a/tests/dialects/test_postgresql.py
+++ b/tests/dialects/test_postgresql.py
@@ -303,3 +303,11 @@ class ReturningClauseTests(unittest.TestCase):
             'ON "xyz"."id"="abc"."xyz" WHERE "abc"."foo"=0 RETURNING "xyz"."a"',
             str(q),
         )
+
+
+class SelectForUpdateTests(unittest.TestCase):
+    table_abc = Table("abc")
+
+    def test_for_no_key_update(self):
+        q = PostgreSQLQuery.from_("abc").select("*").for_update(no_key=True)
+        self.assertEqual('SELECT * FROM "abc" FOR NO KEY UPDATE', str(q))


### PR DESCRIPTION
`SELECT ... FOR UPDATE` is often used when trying to prevent concurrent changes to the same rows. However, at least on PostgreSQL it also blocks e.g. concurrent INSERTs and DELETEs on other tables that have foreign key references to the locked rows, which is only necessary if the referenced keys are changed or the rows are dropped. PostgreSQL offers `SELECT ... FOR NO KEY UPDATE` for use cases that do not require this kind of protection, which can lead to less lock contention in certain use cases.

https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE

## Considerations

This is similar to how Django ORM supports the feature: https://code.djangoproject.com/ticket/30375

The idea is to support the query on Postgres but fall back to the plain `SELECT ... FOR UPDATE` on other databases (like MySQL) without having to change the code or encountering errors.

Alternatively, one could expose the lock strength parameter directly to support `SELECT ... FOR SHARE` and `SELECT ... FOR KEY SHARE` as well. This deviates from the Django ORM design but would be more flexible. Please let me know if you'd prefer that and I'll change the implementation accordingly.

[Corresponding PR](https://github.com/tortoise/tortoise-orm/pull/1949) for tortoise-orm.